### PR TITLE
added fda_unfinished data set

### DIFF
--- a/dags/dynamic_ds_dag.py
+++ b/dags/dynamic_ds_dag.py
@@ -11,7 +11,12 @@ data_set_list = [
         "schedule": "0 6 * * 5",  # run a 6am every thur (url marco minuses day to get wed)
         "url": "https://download.medicaid.gov/data/nadac-national-average-drug-acquisition-cost-{{ macros.ds_format( macros.ds_add(ds ,-1), '%Y-%m-%d', '%m-%d-%Y' ) }}.csv",
         #   "url": "https://download.medicaid.gov/data/nadac-national-average-drug-acquisition-cost-10-20-2021.csv"
-    }
+    },
+    {
+        "dag_id": "fda_unfinished",
+        "schedule": "15 4 * * *",  # run a 4:15am every day
+        "url": "https://www.accessdata.fda.gov/cder/ndc_unfinished.zip",
+    },
 ]
 
 ########################### DYNAMIC DAG DO NOT TOUCH BELOW HERE #################################

--- a/dags/fda_unfinished/load-fda_unfinished_package.sql
+++ b/dags/fda_unfinished/load-fda_unfinished_package.sql
@@ -1,0 +1,14 @@
+/* datasource.fda_unfinished_package */
+DROP TABLE IF EXISTS datasource.fda_unfinished_package;
+
+CREATE TABLE datasource.fda_unfinished_package (
+productid           TEXT NOT NULL,
+productndc          TEXT NOT NULL,             
+ndcpackagecode      TEXT,
+packagedescription  TEXT,
+startmarketingdate  TEXT,
+endmarketingdate    TEXT
+);
+
+COPY datasource.fda_unfinished_package
+FROM '{{ ti.xcom_pull(key='file_path',task_ids='get_fda_unfinished') }}/unfinished_package.txt' (DELIMITER E'\t', NULL '', ENCODING 'WIN1252');

--- a/dags/fda_unfinished/load-fda_unfinished_product.sql
+++ b/dags/fda_unfinished/load-fda_unfinished_product.sql
@@ -1,0 +1,22 @@
+/* datasource.fda_unfinished_product*/
+DROP TABLE IF EXISTS datasource.fda_unfinished_product;
+
+CREATE TABLE datasource.fda_unfinished_product (
+productid                           TEXT,
+productndc                          TEXT,
+producttypename                     TEXT,
+nonproprietaryname                  TEXT,
+dosageformname                      TEXT,
+startmarketingdate                  TEXT,
+endmarketingdate                    TEXT,
+marketingcategoryname               TEXT,
+labelername                         TEXT,
+substancename                       TEXT,
+active_numerator_strength           TEXT,
+active_ingred_unit                  TEXT,
+deaschedule                         TEXT,
+listing_record_certified_through    TEXT
+);
+
+COPY datasource.fda_unfinished_product
+FROM '{{ ti.xcom_pull(key='file_path',task_ids='get_fda_unfinished') }}/unfinished_product.txt' WITH (DELIMITER E'\t', NULL '', ENCODING 'WIN1252');


### PR DESCRIPTION
Added fda_unfinished to dynamic dag

## Explanation
Added dict for fda_unfinished to dynamic dag
added dag folder for fda_unfinished and SQL

## Rationale
To add fda_unfinished. No alternatives were reviewed

## Tests
1. What testing did you do? ran fda_unfinished dag to completion
1. Attach testing logs inside a summary block:

<details>
<summary>testing logs</summary>

[2021-10-23 02:57:59,132] {dbapi.py:204} INFO - Running statement: /* datasource.fda_unfinished_package */
DROP TABLE IF EXISTS datasource.fda_unfinished_package;

CREATE TABLE datasource.fda_unfinished_package (
productid           TEXT NOT NULL,
productndc          TEXT NOT NULL,             
ndcpackagecode      TEXT,
packagedescription  TEXT,
startmarketingdate  TEXT,
endmarketingdate    TEXT
);

COPY datasource.fda_unfinished_package
FROM '/opt/***/data/fda_unfinished/ndc_unfinished/unfinished_package.txt' (DELIMITER E'\t', NULL '', ENCODING 'WIN1252');, parameters: None
[2021-10-23 02:57:59,309] {dbapi.py:212} INFO - Rows affected: 31185
[2021-10-23 02:57:59,335] {postgres.py:71} INFO - NOTICE:  table "fda_unfinished_package" does not exist, skipping

[2021-10-23 02:57:59,386] {taskinstance.py:1219} INFO - Marking task as SUCCESS. dag_id=fda_unfinished, task_id=load-fda_unfinished_package.sql, execution_date=20211023T025755, start_date=20211023T025758, end_date=20211023T025759
[2021-10-23 02:57:59,482] {local_task_job.py:151} INFO - Task exited with return code 0
[2021-10-23 02:57:59,585] {local_task_job.py:261} INFO - 0 downstream tasks scheduled from follow-on schedule check

</details>

