### PR TITLE
Kent/combine dict dynamic dag

### DIFF
--- a/dags/dynamic_ds_dag.py
+++ b/dags/dynamic_ds_dag.py
@@ -63,6 +63,7 @@ def create_dag(dag_args):
 
     dag_id = dag_args["dag_id"]
     url = dag_args["url"]
+    retrieve_dataset_function = dag_args["retrieve_dataset_function"]
 
     dag = DAG(dag_id, default_args=dag_args, description=f"Processes {dag_id} source")
 
@@ -74,7 +75,7 @@ def create_dag(dag_args):
         # Task to download data from web location
         get_data = PythonOperator(
             task_id=f"get_{dag_id}",
-            python_callable=get_dataset,
+            python_callable=retrieve_dataset_function,
             op_kwargs={"ds_url": url, "data_folder": data_folder},
         )
 
@@ -132,6 +133,8 @@ for ds in data_set_list:
         "email_on_retry": False,
         "retries": 1,
         "retry_delay": timedelta(minutes=5),
+        # none airflow common dag elements
+        "retrieve_dataset_function": get_dataset,
     }
 
     dag_args = {**default_args, **ds}


### PR DESCRIPTION
Fixes coderxio/sagerx #7 

## Explanation
added a feature that merges the dataset dict with default_args dict 
Modified create_dag so that the function which retrieves the dataset from the web can be swapped by adding a key value of retrieve_dataset_function to the dataset dict in ds_dict_list and a callable is passed as the value

## Rationale
so that default_args can be overriden by passing them as optional parameters to dataset dict in ds_dict_list.
Made our dynamic dag more flexible for complex web downloading process


## Tests
1. What testing did you do? ran three data sets
1. Attach testing logs inside a summary block:

<details>
<summary>testing logs</summary>
[2021-11-05 20:37:03,292] {taskinstance.py:1219} INFO - Marking task as SUCCESS. dag_id=fda_excluded, task_id=load-fda_excluded_products.sql, execution_date=20211105T203657, start_date=20211105T203702, end_date=20211105T203703
</details>

