### PR TITLE
Kent/fix schedule interval

### DIFF
--- a/dags/dynamic_ds_dag.py
+++ b/dags/dynamic_ds_dag.py
@@ -117,6 +117,7 @@ def create_dag(dag_args):
 
     dag = DAG(
         dag_id,
+        schedule_interval=dag_args["schedule_interval"],
         default_args=dag_args,
         description=f"Processes {dag_id} source",
         user_defined_macros=dag_args.get("user_defined_macros"),


### PR DESCRIPTION
Resolves #28 

## Explanation
Updated keys in ds_dict entries to be schedule_interval per airflow variable name
Added parameter for schedule_interval to create_dag so dags have
correct schedule interval

## Rationale
Allows for modification of intervals using ds_dict.

## Tests
1. What testing did you do? reviewed schedule intervals in airflow
1. Attach testing logs inside a summary block:

<details>
<summary>testing logs</summary>

![image](https://user-images.githubusercontent.com/40433162/141867254-962487f6-1507-407e-831c-e400b2e59c09.png)
</details>

