### PR TITLE
Add port to docker-compose

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -22,6 +22,8 @@ services:
       POSTGRES_USER: sagerx
       POSTGRES_PASSWORD: sagerx
       POSTGRES_DB: sagerx
+    ports:
+      - 5432:5432
     volumes:
       - ./postgres:/docker-entrypoint-initdb.d
       - ./data:/opt/airflow/data


### PR DESCRIPTION
Resolves #52 

## Explanation
Exposed a port to connect to postgres.

## Rationale
Wanted to use Azure Data Studio to write queries and save to my local PC.

NOTE: Azure Data Studio requires Postgres extension for this to work.

## Tests
Connected with Azure Data Studio and DBeaver.