### PR TITLE
Fix fda_ndc_class columns

### DIFF
--- a/dags/fda_ndc/staging-fda_ndc_class.sql
+++ b/dags/fda_ndc/staging-fda_ndc_class.sql
@@ -3,11 +3,10 @@ DROP TABLE IF EXISTS staging.fda_ndc_class;
 
 CREATE TABLE staging.fda_ndc_class (
 	productid	TEXT NOT NULL,
-	productndc 	TEXT NOT NULL,
 	class_line 	TEXT NOT NULL,
 	class_name 	TEXT,
 	class_type 	TEXT,
-	PRIMARY KEY (productid,productndc,class_line)
+	PRIMARY KEY (productid,class_line)
 );
 
 INSERT INTO staging.fda_ndc_class


### PR DESCRIPTION
## Explanation
The fda_ndc_class DAG had a mismatch of columns in the CREATE TABLE and INSERT INTO sections.  This meant all columns were off by one.  I removed the NDC column because the productid is really the primary key (in conjunction with class_line).

## Rationale
I was trying to run a query and it was broken because of this.

## Tests
Ran DAG and executed this query (which was broken before, but is now fixed).
```
SELECT
	cls.class_name
	, COUNT(*)
FROM staging.fda_ndc ndc
LEFT JOIN staging.fda_ndc_class cls
	ON ndc.productid = cls.productid
WHERE to_date(startmarketingdate, 'YYYYMMDD') >= current_date - 90
	AND cls.class_type = 'EPC'
GROUP BY cls.class_name
ORDER BY COUNT(*) DESC;
```