### PR TITLE
Update dailymed to dailymed_rx_full

### DIFF
--- a/dags/dailymed_daily/dailymed_daily_dag.py
+++ b/dags/dailymed_daily/dailymed_daily_dag.py
@@ -57,7 +57,7 @@ def process_dailymed(data_folder, xslt, ti):
                     xml_content = transform_xml(new_file, xslt)
                     os.remove(new_file)
                     df = pd.DataFrame(
-                        columns=["slp", "file_name", "xml_content"],
+                        columns=["spl", "file_name", "xml_content"],
                         data=[[folder_name, subfile.filename, xml_content]],
                     )
                     df.to_sql(

--- a/dags/dailymed_rx_full/dailymed_prescription.xsl
+++ b/dags/dailymed_rx_full/dailymed_prescription.xsl
@@ -1,0 +1,90 @@
+<xsl:transform version="1.0" 
+            				 xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+							 xmlns:v3="urn:hl7-org:v3" 
+							 xmlns:v="http://validator.pragmaticdata.com/result" 
+							 xmlns:str="http://exslt.org/strings" 
+							 xmlns:exsl="http://exslt.org/common" 
+							 xmlns:msxsl="urn:schemas-microsoft-com:xslt" 
+							 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+							 exclude-result-prefixes="exsl msxsl v3 xsl xsi str v">                
+<xsl:output method="xml" indent="yes"/> 
+
+<xsl:template match="/">
+    <dailymed>
+        <xsl:apply-templates select="v3:document"/>
+        <xsl:apply-templates select="v3:document/v3:component"/>
+        <xsl:apply-templates select="//v3:code[@code='34073-7']"/>
+        <xsl:apply-templates select="/v3:document/v3:author/v3:assignedEntity/v3:representedOrganization"/>
+    </dailymed>
+</xsl:template>
+
+<!-- header --> 
+<xsl:template match="v3:document">
+    <documentId><xsl:value-of select="/v3:document/v3:id/@root"/></documentId>
+    <SetId><xsl:value-of select="/v3:document/v3:setId/@root"/></SetId>
+    <VersionNumber><xsl:value-of select="/v3:document/v3:versionNumber/@value"/></VersionNumber>
+    <EffectiveDate><xsl:value-of select="/v3:document/v3:effectiveTime/@value"/></EffectiveDate>
+    <MarketStatus><xsl:value-of select="//v3:subjectOf/v3:approval/v3:code/@displayName"/></MarketStatus>
+    <ApplicationNumber><xsl:value-of select="//v3:subjectOf/v3:approval/v3:id/@extension"/></ApplicationNumber>
+</xsl:template>
+
+<!-- NDC -->
+<xsl:template match="v3:document/v3:component">
+    <ndc_list>
+    <xsl:for-each select="//v3:containerPackagedProduct/v3:code[@codeSystem='2.16.840.1.113883.6.69']">  
+        <NDC><xsl:value-of select="./@code"/></NDC>
+    </xsl:for-each>
+    </ndc_list>
+</xsl:template>
+
+<!--Drug Interactions -->
+<xsl:template match="//v3:code[@code='34073-7']"> 
+    <InteractionText>
+        <xsl:value-of select=".."/>
+    </InteractionText>
+
+</xsl:template>
+
+<!-- establishment info -->
+<xsl:template match="/v3:document/v3:author/v3:assignedEntity/v3:representedOrganization">
+    <Organizations> 
+        <establishment>
+            <DUN><xsl:value-of select="./v3:id/@extension"/></DUN>
+            <name><xsl:value-of select="./v3:name"/></name>
+            <xsl:choose> 
+                <xsl:when test="//v3:asEquivalentEntity/v3:code/@code = 'C64637'">
+                    <type>Repacker</type>
+                    <source_list>
+                    <xsl:for-each select="//v3:asEquivalentEntity/v3:code[@code='C64637']/../v3:definingMaterialKind/v3:code">
+                        <source><xsl:value-of select="./@code"/></source>
+                    </xsl:for-each>
+                    </source_list>
+                </xsl:when>
+                <xsl:otherwise>
+                    <type>Labeler</type>  
+                </xsl:otherwise>
+            </xsl:choose>
+        </establishment>
+        
+        <xsl:for-each select="./v3:assignedEntity/v3:assignedOrganization/v3:assignedEntity/v3:assignedOrganization">
+        <establishment>
+            <DUN><xsl:value-of select="./v3:id[@root='1.3.6.1.4.1.519.1']/@extension"/><xsl:if test="./v3:id[@root='1.3.6.1.4.1.519.1']/@extension and ./v3:id[not(@root='1.3.6.1.4.1.519.1')]/@extension">/</xsl:if><xsl:value-of select="./v3:id[not(@root='1.3.6.1.4.1.519.1')]/@extension"/></DUN>
+            <name><xsl:value-of select="./v3:name"/></name>
+            <type>Functioner</type>
+                <xsl:for-each select="../v3:performance[not(v3:actDefinition/v3:code/@code = preceding-sibling::*/v3:actDefinition/v3:code/@code)]/v3:actDefinition/v3:code">
+                    <xsl:variable name="code" select="@code"/>
+                    <function>
+                        <name><xsl:value-of select="@displayName"/></name>
+                        <item_list>
+                        	    <xsl:for-each select="../../../v3:performance/v3:actDefinition[v3:code/@code = $code]/v3:product/v3:manufacturedProduct/v3:manufacturedMaterialKind/v3:code/@code">
+								<item><xsl:value-of select="."/></item>
+                              </xsl:for-each>
+                        </item_list>
+                    </function>
+                </xsl:for-each>
+        </establishment>  
+        </xsl:for-each>
+       </Organizations> 
+</xsl:template>
+
+</xsl:transform>

--- a/dags/dailymed_rx_full/staging-dailymed_interaction.sql
+++ b/dags/dailymed_rx_full/staging-dailymed_interaction.sql
@@ -1,0 +1,29 @@
+ /* staging.dailymed_interaction */
+ DROP TABLE IF EXISTS staging.dailymed_interaction CASCADE;
+
+ CREATE TABLE IF NOT EXISTS staging.dailymed_interaction (
+	spl 					TEXT NOT NULL,
+	document_id 			TEXT NOT NULL,
+	set_id			 		TEXT,
+	version_number 			TEXT,
+   	interaction_text		TEXT
+); 
+
+with xml_table as
+(
+select spl, xml_content::xml as xml_column
+from datasource.dailymed_rx_full
+)
+
+INSERT INTO staging.dailymed_interaction
+SELECT spl, y.*
+    FROM   xml_table x,
+            XMLTABLE('dailymed/InteractionText'
+              PASSING xml_column
+              COLUMNS 
+                document_id 	 TEXT  PATH '../documentId',
+				set_id  		 TEXT  PATH '../SetId',
+				version_number	 TEXT  PATH '../VersionNumber',
+				interaction_text TEXT PATH '.'
+					) y
+ON CONFLICT DO NOTHING;

--- a/dags/dailymed_rx_full/staging-dailymed_main.sql
+++ b/dags/dailymed_rx_full/staging-dailymed_main.sql
@@ -1,0 +1,35 @@
+ /* staging.dailymed_main */
+ DROP TABLE IF EXISTS staging.dailymed_main CASCADE;
+
+ CREATE TABLE IF NOT EXISTS staging.dailymed_main (
+	spl 				TEXT NOT NULL,
+	document_id 		TEXT NOT NULL,
+	set_id			 	TEXT,
+	version_number 		TEXT,
+   	effective_date 		TEXT,
+	market_status		TEXT,
+	application_number	TEXT,
+	dailymed_url		TEXT
+); 
+
+with xml_table as
+(
+select spl, xml_content::xml as xml_column
+from datasource.dailymed_rx_full
+)
+
+INSERT INTO staging.dailymed_main
+SELECT spl, y.*, 'https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=' || y.set_id
+    FROM   xml_table x,
+            XMLTABLE('dailymed'
+              PASSING xml_column
+              COLUMNS 
+                document_id 	TEXT  PATH './documentId',
+				set_id  		TEXT  PATH './SetId',
+				version_number	TEXT  PATH './VersionNumber',
+  				effective_date	TEXT  PATH './EffectiveDate',
+				market_status	TEXT  PATH './MarketStatus',
+				application_number TEXT PATH './ApplicationNumber'
+
+					) y
+ON CONFLICT DO NOTHING;

--- a/dags/dailymed_rx_full/staging-dailymed_ndc.sql
+++ b/dags/dailymed_rx_full/staging-dailymed_ndc.sql
@@ -1,0 +1,28 @@
+ /* staging.dailymed_ndc */
+ --DROP TABLE IF EXISTS staging.dailymed_ndc CASCADE;
+
+ CREATE TABLE IF NOT EXISTS staging.dailymed_ndc (
+	spl 				TEXT NOT NULL,
+	document_id 		TEXT NOT NULL,
+	set_id			 	TEXT,
+	ndc 				TEXT,
+   	ndc11 				TEXT
+); 
+
+with xml_table as
+(
+select spl, xml_content::xml as xml_column
+from datasource.dailymed_rx_full
+)
+
+INSERT INTO staging.dailymed_ndc
+SELECT spl, y.*, ndc_to_11(y.ndc) AS ndc11
+    FROM   xml_table x,
+            XMLTABLE('dailymed/ndc_list/NDC'
+              PASSING xml_column
+              COLUMNS 
+                document_id 	TEXT  PATH '../../documentId',
+				set_id  		TEXT  PATH '../../SetId',
+				ndc				TEXT  PATH '.'
+					) y
+ON CONFLICT DO NOTHING;

--- a/dags/dailymed_rx_full/staging-dailymed_organization.sql
+++ b/dags/dailymed_rx_full/staging-dailymed_organization.sql
@@ -1,0 +1,31 @@
+ /* staging.dailymed_organization */
+ --DROP TABLE IF EXISTS staging.dailymed_organization CASCADE;
+
+ CREATE TABLE IF NOT EXISTS staging.dailymed_organization (
+	spl 				TEXT NOT NULL,
+	document_id 		TEXT NOT NULL,
+	set_id			 	TEXT,
+	dun					TEXT,
+	org_name			TEXT,
+	org_type			TEXT
+); 
+
+with xml_table as
+(
+select spl, xml_content::xml as xml_column
+from datasource.dailymed_rx_full
+)
+
+INSERT INTO staging.dailymed_organization
+SELECT spl, y.*
+    FROM   xml_table x,
+            XMLTABLE('/dailymed/Organizations/establishment'
+              PASSING xml_column
+              COLUMNS 
+                document_id 	TEXT  PATH '../../documentId',
+				set_id  		TEXT  PATH '../../SetId',
+				dun				TEXT  PATH './DUN',
+	            org_name		TEXT  PATH './name',
+	            org_type		TEXT  PATH './type'
+					) y
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Explanation
Updated the dailymed DAG with functionality from dailymed_daily.  We will really need to clean these two DAGs up soon as they share a lot of duplicate code.

## Rationale
I wanted to get drug interactions for the full 40k SPLs and this allowed me to accomplish that.

## Tests
Ran DAG and queried pgAdmin.

Example query to get from drug ingredient -> drug interaction text:
```
select distinct
	ri.ingredient_rxcui
	, ri.ingredient_name
	, ri.ingredient_tty
	, di.set_id
	, regexp_replace(di.interaction_text, '[^a-zA-Z\d\s:]+', '', 'g') as interaction_text
from staging.dailymed_interaction di
left join datasource.dailymed_rxnorm dr on dr.setid = di.set_id and dr.spl_version = di.version_number
left join flatfile.rxnorm_clinical_product_to_ingredient ri on ri.clinical_product_rxcui = dr.rxcui
where dr.rxtty = 'SCD';
```