### PR TITLE
Create ndc_to_product

### DIFF
--- a/dags/rxnorm_full/view-rxnorm_ndc_to_product.sql
+++ b/dags/rxnorm_full/view-rxnorm_ndc_to_product.sql
@@ -1,0 +1,14 @@
+/* flatfile.rxnorm_ndc_to_product */
+CREATE OR REPLACE VIEW flatfile.rxnorm_ndc_to_product
+AS 
+    select
+        ndc
+        , coalesce(rbp.rxcui, rcp.rxcui, null) as rxcui
+        , coalesce(rbp.name, rcp.name, null) as name
+        , coalesce(rbp.tty, rcp.tty, null) as tty
+    from staging.rxnorm_ndc ndc
+    left join staging.rxnorm_clinical_product rcp 
+        on ndc.clinical_product_rxcui = rcp.rxcui
+    left join staging.rxnorm_brand_product rbp
+        on ndc.brand_product_rxcui = rbp.rxcui
+    where ndc.active and ndc.prescribable


### PR DESCRIPTION
Resolves #148 

## Explanation
Added a view for NDC to product (prefer brand if exists).

## Rationale
Wanted to be able to compare NDCs by RXCUI and know if the NDC was brand or generic.

## Tests
VLOOKUP'd output to some NDC in a spreadsheet.