### PR TITLE
Update dbt-postgres to 1.5.1

### DIFF
--- a/dbt/Dockerfile
+++ b/dbt/Dockerfile
@@ -5,7 +5,7 @@ ENV DBT_PROFILES_DIR=/dbt
 RUN apt-get -y update
 RUN apt-get -y install git
 
-RUN pip install dbt-postgres==1.4.1
+RUN pip install dbt-postgres==1.5.1
 
 WORKDIR /dbt
 


### PR DESCRIPTION
Fixes #190

Used to be 1.4.1 but had a pytz dependency

## Explanation
See #190 

## Rationale
See #190 

## Tests
Did docker-compose up --build and then ran dbt --version in dbt container.  Docker-compose down and then re-up with no --build and ran the dbt --version command again and everything still worked.