### PR TITLE
Set start_date and schedule for RxNorm DAG

### DIFF
--- a/airflow/dags/rxnorm/rxnorm_dag.py
+++ b/airflow/dags/rxnorm/rxnorm_dag.py
@@ -12,8 +12,8 @@ from airflow.hooks.subprocess import SubprocessHook
 
 
 @dag(
-    schedule="0 0 1 * *",
-    start_date=pendulum.yesterday(),
+    schedule="0 0 10 * *",
+    start_date=pendulum.datetime(2005, 1, 1),
     catchup=False,
 )
 def rxnorm():


### PR DESCRIPTION
Resolves #191 

## Explanation
Changed RxNorm to start on day 10 of the month to account for variety of days of month of updating from NLM.  Also set an actual hard coded start date of 1/1/2005.  It's an aribrary date, but that's the date the RxNorm data started being available.

## Rationale
So RxNorm would refresh every month.

## Tests
Changed the start time and waited and it auto-ran.  Also, once I made the change, it ran as soon as I turned the DAG on in addition to auto-running at the appropriate time.