### PR TITLE
Materialize RxNorm

### DIFF
--- a/dbt/sagerx/dbt_project.yml
+++ b/dbt/sagerx/dbt_project.yml
@@ -33,10 +33,10 @@ models:
   sagerx:
     staging:
       +schema: staging
-      +materialized: view
+      +materialized: table
     intermediate:
       +schema: intermediate
-      +materialized: view
+      +materialized: table
     marts:
       +schema: marts
       +materialized: view


### PR DESCRIPTION
## Explanation
RxNorm is super slow to work with unless materialized, or unless we optimize the views.

For now, I am going to materialize the tables b/c I've tested it before and I know it works.

## Rationale
RxNorm is pretty unusable right now.

We might want to reconsider this later - and might need to update other DAGs like fda_enforcement.

## Tests
Tested this both locally and on the server and it works both places.