### PR TITLE
Use psycopg2 2.9.6 which includes libpq 15

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,2 +1,2 @@
 FROM apache/airflow:2.5.1
-RUN pip install --no-cache-dir dbt-postgres==1.4.1
+RUN pip install --no-cache-dir dbt-postgres==1.4.1 psycopg2-binary==2.9.6


### PR DESCRIPTION
This is something to consider vs what normally gets installed which is psycopg2 2.9.5. If this route is interesting but we want to be less restrictive, we could consider an install of 2.9.6 only if the system architecture is aarch64/arm64.