### PR TITLE
RxNorm Historical NDCs and RxClass ATCPROD (ATC codes -> Product RXCUIs)

### DIFF
--- a/airflow/dags/rxnorm_historical/rxnorm_historical.py
+++ b/airflow/dags/rxnorm_historical/rxnorm_historical.py
@@ -1,0 +1,91 @@
+import numpy as np
+import pandas as pd
+import os
+from time import sleep
+import requests
+from requests.adapters import HTTPAdapter, Retry
+
+from pathlib import Path
+import pendulum
+
+from sagerx import get_dataset, read_sql_file, get_sql_list, alert_slack_channel
+
+from airflow.decorators import dag, task
+
+from airflow.operators.python import get_current_context
+from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.hooks.postgres_hook import PostgresHook
+from airflow.hooks.subprocess import SubprocessHook
+
+
+@dag(
+    schedule="0 4 * * *",
+    start_date=pendulum.yesterday(),
+    catchup=False,
+)
+def rxnorm_historical():
+    dag_id = "rxnorm_historical"
+
+    def get_atc_from_rxcui(rxcui):
+        try:
+            s = requests.Session()
+            retries = Retry(total=5,
+                            backoff_factor=0.5)
+            s.mount('https://', HTTPAdapter(max_retries=retries))
+            response = s.get(f'https://rxnav.nlm.nih.gov/REST/rxclass/class/byRxcui.json?rxcui={rxcui}&relaSource=ATCPROD')
+            response.raise_for_status()
+            jsonResponse = response.json()
+            resp = jsonResponse["rxclassDrugInfoList"]["rxclassDrugInfo"][0]["rxclassMinConceptItem"]
+            return resp
+        except Exception as e:
+            print(e)
+            return -1
+
+    # Task to download data from web location
+    @task
+    def extract():
+        # Define list of rxcui
+
+        # For example
+        rxcui_list = [198335]
+
+        # Get ATC for full list of RXCUI
+        atcs = {}
+        failed_atc = []
+
+        for rxcui in rxcui_list:
+            sleep(0.1)
+            atc = get_atc_from_rxcui(rxcui)
+            if atc == -1:
+                failed_atc.append(rxcui)
+            else:
+                atcs[rxcui] = atc
+
+        atc_df = pd.DataFrame.from_dict(atcs, orient='index').reset_index()
+        print(atc_df.head(10))
+
+    # Task to load data into source db schema
+    load = []
+    ds_folder = Path("/opt/airflow/dags") / dag_id
+    for sql in get_sql_list("load", ds_folder):
+        sql_path = ds_folder / sql
+        task_id = sql[:-4]
+        load.append(
+            PostgresOperator(
+                task_id=task_id,
+                postgres_conn_id="postgres_default",
+                sql=read_sql_file(sql_path),
+            )
+        )
+
+    # Task to transform data using dbt
+    @task
+    def transform():
+        subprocess = SubprocessHook()
+        result = subprocess.run_command(['dbt', 'run', '--select', 'models/staging/fda_ndc'], cwd='/dbt/sagerx')
+        print("Result from dbt:", result)
+
+    #extract() >> load >> transform()
+    extract()
+
+rxnorm_historical()

--- a/airflow/dags/rxnorm_historical/rxnorm_historical_dag.py
+++ b/airflow/dags/rxnorm_historical/rxnorm_historical_dag.py
@@ -3,6 +3,7 @@ import pandas as pd
 from time import sleep
 import requests
 from requests.adapters import HTTPAdapter, Retry
+import sqlalchemy
 
 from pathlib import Path
 import pendulum
@@ -22,8 +23,8 @@ from airflow.hooks.subprocess import SubprocessHook
     start_date=pendulum.yesterday(),
     catchup=False,
 )
-def rxclass_atc_to_product():
-    dag_id = "rxclass_atc_to_product"
+def rxnorm_historical():
+    dag_id = "rxnorm_historical"
     data_folder = Path("/opt/airflow/data") / dag_id
     file_name = f'{dag_id}.csv'
     file_path = create_path(data_folder) / file_name
@@ -36,7 +37,7 @@ def rxclass_atc_to_product():
         engine = pg_hook.get_sqlalchemy_engine()
 
         df = pd.read_sql(
-            "select distinct rxcui from datasource.rxnorm_rxnconso where tty in ('SCD','SBD','GPCK','BPCK') and sab = 'RXNORM' limit 100",
+            "select distinct rxcui from datasource.rxnorm_rxnconso where tty in ('SCD','SBD','GPCK','BPCK') and sab = 'RXNORM'",
             con=engine
         )
 
@@ -47,16 +48,16 @@ def rxclass_atc_to_product():
         
         return file_path_str
 
-    def get_atc_from_rxcui(rxcui):
+    def get_historical_ndcs(rxcui):
         try:
             s = requests.Session()
             retries = Retry(total=5,
                             backoff_factor=0.5)
             s.mount('https://', HTTPAdapter(max_retries=retries))
-            response = s.get(f'https://rxnav.nlm.nih.gov/REST/rxclass/class/byRxcui.json?rxcui={rxcui}&relaSource=ATCPROD')
+            response = s.get(f'https://rxnav.nlm.nih.gov/REST/rxcui/{rxcui}/allhistoricalndcs.json')
             response.raise_for_status()
-            jsonResponse = response.json()
-            resp = jsonResponse["rxclassDrugInfoList"]["rxclassDrugInfo"][0]["rxclassMinConceptItem"]
+            resp = response.json()
+            #resp = jsonResponse["rxclassDrugInfoList"]["rxclassDrugInfo"][0]["rxclassMinConceptItem"]
             return resp
         except Exception as e:
             print(e)
@@ -68,31 +69,36 @@ def rxclass_atc_to_product():
         data = pd.read_csv(file_path)
         rxcui_list = data['rxcui'].to_list()
 
-        # Get ATC for full list of RXCUI
-        atcs = {}
+        # Get historical NDCs for full list of RXCUI
+        ndcs = {}
         failed_atc = []
 
         for rxcui in rxcui_list:
             sleep(0.1)
-            atc = get_atc_from_rxcui(rxcui)
-            if atc == -1:
+            ndc = get_historical_ndcs(rxcui)
+            if ndc == -1:
                 failed_atc.append(rxcui)
             else:
-                atcs[rxcui] = atc
+                ndcs[rxcui] = ndc
 
-        atc_df = pd.DataFrame.from_dict(atcs, orient='index').reset_index()
-        print(atc_df.head(10))
+        ndc_df = pd.DataFrame.from_dict(ndcs, orient='index').reset_index()
+        ndc_df.columns = ['rxcui', 'ndcs']
+        print(ndc_df.head(10))
 
         pg_hook = PostgresHook(postgres_conn_id="postgres_default")
         engine = pg_hook.get_sqlalchemy_engine()
 
-        atc_df.to_sql(
-            "rxclass_atc_to_product",
+        ndc_df.to_sql(
+            "rxnorm_historical",
             con=engine,
             schema="datasource",
             if_exists="replace",
+            dtype={"ndcs": sqlalchemy.types.JSON},
             index=False
         )
+
+
+
 
     # Task to load data into source db schema
     load = []
@@ -115,7 +121,6 @@ def rxclass_atc_to_product():
         result = subprocess.run_command(['dbt', 'run', '--select', 'models/staging/fda_ndc'], cwd='/dbt/sagerx')
         print("Result from dbt:", result)
 
-    #extract() >> load >> transform()
     extract(get_rxcuis())
 
-rxclass_atc_to_product()
+rxnorm_historical()

--- a/dbt/sagerx/models/intermediate/ndc/int_ndc_all_ndcs_to_sources.sql
+++ b/dbt/sagerx/models/intermediate/ndc/int_ndc_all_ndcs_to_sources.sql
@@ -1,0 +1,81 @@
+-- stg_ndc_all_ndcs_to_sources.sql
+
+with rxnorm_historical_ndcs as
+(
+    -- NOTE: likely need to pick the most recent NDC
+    -- instead of just distinct
+    -- and pull in the other columns too possibly
+    select distinct ndc
+    from {{ ref('stg_rxnorm_historical__ndcs') }}
+)
+
+, rxnorm_all_ndcs as
+(
+    select distinct ndc11 as ndc
+    from {{ ref('stg_rxnorm__all_ndcs') }}
+)
+
+, fda_ndc_ndcs as
+(
+    select distinct ndc11 as ndc
+    from {{ ref('stg_fda_ndc__ndc') }}
+)
+
+, fda_excluded_ndcs as
+(
+    select distinct ndc11 as ndc
+    from staging.fda_excluded
+)
+
+, fda_unfinished_ndcs as
+(
+    select distinct ndc11 as ndc
+    from staging.fda_unfinished
+)
+
+, all_distinct_ndcs as
+(
+    select ndc from rxnorm_historical_ndcs
+    union
+    select ndc from rxnorm_all_ndcs
+    union
+    select ndc from fda_ndc_ndcs
+    union
+    select ndc from fda_excluded_ndcs
+    union
+    select ndc from fda_unfinished_ndcs
+)
+
+select
+    all_distinct_ndcs.ndc
+    , case when rxnorm_historical_ndcs.ndc is not null
+        then 1 
+        else 0
+        end as rxnorm_historical_ndcs
+    , case when rxnorm_all_ndcs.ndc is not null
+        then 1 
+        else 0
+        end as rxnorm_all_ndcs
+    , case when fda_ndc_ndcs.ndc is not null
+        then 1 
+        else 0
+        end as fda_ndc_ndcs
+    , case when fda_excluded_ndcs.ndc is not null
+        then 1 
+        else 0
+        end as fda_excluded_ndcs
+    , case when fda_unfinished_ndcs.ndc is not null
+        then 1 
+        else 0
+        end as fda_unfinished_ndcs
+from all_distinct_ndcs
+left join rxnorm_historical_ndcs
+    on rxnorm_historical_ndcs.ndc = all_distinct_ndcs.ndc
+left join rxnorm_all_ndcs
+    on rxnorm_all_ndcs.ndc = all_distinct_ndcs.ndc
+left join fda_ndc_ndcs
+    on fda_ndc_ndcs.ndc = all_distinct_ndcs.ndc
+left join fda_excluded_ndcs
+    on fda_excluded_ndcs.ndc = all_distinct_ndcs.ndc
+left join fda_unfinished_ndcs
+    on fda_unfinished_ndcs.ndc = all_distinct_ndcs.ndc

--- a/dbt/sagerx/models/intermediate/rxnorm/int_rxnorm_all_ndcs_to_product_rxcuis.sql
+++ b/dbt/sagerx/models/intermediate/rxnorm/int_rxnorm_all_ndcs_to_product_rxcuis.sql
@@ -1,0 +1,18 @@
+with all_ndcs as
+(
+    select * from {{ ref('stg_rxnorm__all_ndcs') }}
+),
+
+product_rxcuis as
+(
+    select * from datasource.rxnorm_rxnconso
+    where sab = 'RXNORM'
+        and tty in ('SCD', 'SBD', 'GPCK', 'BPCK')
+)
+
+select distinct
+    all_ndcs.ndc11
+    , product_rxcuis.rxcui
+from all_ndcs
+inner join product_rxcuis
+    on all_ndcs.rxcui = product_rxcuis.rxcui

--- a/dbt/sagerx/models/staging/rxnorm/stg_rxnorm__all_ndcs.sql
+++ b/dbt/sagerx/models/staging/rxnorm/stg_rxnorm__all_ndcs.sql
@@ -1,0 +1,11 @@
+-- stg_rxnorm__all_ndcs.sql
+
+select
+    ndc_to_11(rxnsat.atv) as ndc11
+    , rxnsat.atv as ndc
+    , rxnsat.rxcui
+    , rxnsat.sab
+	, case when rxnsat.suppress = 'N' then true else false end as active
+	, case when rxnsat.cvf = '4096' then true else false end as prescribable
+from datasource.rxnorm_rxnsat rxnsat
+    where rxnsat.atn = 'NDC'

--- a/dbt/sagerx/models/staging/rxnorm/stg_rxnorm__mthspl_ndcs.sql
+++ b/dbt/sagerx/models/staging/rxnorm/stg_rxnorm__mthspl_ndcs.sql
@@ -1,0 +1,11 @@
+-- stg_rxnorm__mthspl_ndcs.sql
+
+select
+    ndc_to_11(rxnsat.atv) as ndc11
+    , rxnsat.atv as ndc
+    , rxnsat.rxcui
+	, case when rxnsat.suppress = 'N' then true else false end as active
+	, case when rxnsat.cvf = '4096' then true else false end as prescribable
+from datasource.rxnorm_rxnsat rxnsat
+    where rxnsat.atn = 'NDC'
+        and rxnsat.sab = 'MTHSPL'

--- a/dbt/sagerx/models/staging/rxnorm_historical/_rxnorm_historical__sources.yml
+++ b/dbt/sagerx/models/staging/rxnorm_historical/_rxnorm_historical__sources.yml
@@ -1,0 +1,7 @@
+version: 2
+
+sources:
+  - name: rxnorm_historical
+    schema: datasource
+    tables:
+      - name: rxnorm_historical

--- a/dbt/sagerx/models/staging/rxnorm_historical/stg_rxnorm_historical__ndcs.sql
+++ b/dbt/sagerx/models/staging/rxnorm_historical/stg_rxnorm_historical__ndcs.sql
@@ -1,0 +1,11 @@
+select
+    rxcui,
+    (ndc_item->>'ndc')::json->>0 as ndc,
+    ndc_item->>'startdate' as start_date,
+    ndc_item->>'enddate' as end_date,
+    case when item->>'status' = 'indirect'
+        then item->>'rxcui'
+        end as indirect_rxcui
+from datasource.rxnorm_historical
+cross join lateral json_array_elements(ndcs->'historicalndctime') as item
+cross join lateral json_array_elements(item->'ndctime') as ndc_item

--- a/dbt/sagerx/models/staging/rxnorm_historical/stg_rxnorm_historical__ndcs.sql
+++ b/dbt/sagerx/models/staging/rxnorm_historical/stg_rxnorm_historical__ndcs.sql
@@ -1,11 +1,13 @@
+-- stg_rxnorm_historical__ndcs.sql
+
 select
     rxcui,
     (ndc_item->>'ndc')::json->>0 as ndc,
-    ndc_item->>'startdate' as start_date,
-    ndc_item->>'enddate' as end_date,
+    ndc_item->>'startDate' as start_date,
+    ndc_item->>'endDate' as end_date,
     case when item->>'status' = 'indirect'
         then item->>'rxcui'
         end as indirect_rxcui
 from datasource.rxnorm_historical
-cross join lateral json_array_elements(ndcs->'historicalndctime') as item
-cross join lateral json_array_elements(item->'ndctime') as ndc_item
+    cross join lateral json_array_elements(ndcs->'historicalNdcTime') as item
+    cross join lateral json_array_elements(item->'ndcTime') as ndc_item

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,9 @@ services:
       - ./postgres:/docker-entrypoint-initdb.d
       - ./airflow/data:/opt/airflow/data
       - ./airflow/extracts:/opt/airflow/extracts
+    build:
+      context: .
+      shm_size: '4gb'
 
   pgadmin:
     image: dpage/pgadmin4:6.15


### PR DESCRIPTION
Resolves #32 
Resolves #56

## Explanation
Added a DAG for RxNorm Historical and one for RxClass ATC.  Both use the respective APIs to loop through all product-level RXCUIs (TTY = SCD, SBD, GPCK, BPCK) in RxNorm (about 60k+) which takes about 5 hours per DAG to run to completion.  The ATC DAG just gets the ATC code from the JSON response.  The RxNorm Historical DAG saves the entire JSON object and then parses through it with PostgreSQL in a second task.

I also added a first pass at a "main NDC" table that contains NDCs from ALL sources (FDA, RxNorm, etc) and an indicator of which source the NDC came from.

Future work is needed to incrementally add historical NDCs from the RxNorm API with each monthly RxNorm release.  I didn't get to that as part of this PR.

## Rationale
We had considered downloading every single archived version of RxNorm and trying to find the historical NDCs this way, but a colleague pointed out that the API did exactly that to achieve this so it was kind of silly to re-invent the wheel if we could just hit the API a bunch.

## Tests
Ran DAGs to completion.