### PR TITLE
Update DBT for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SageRx is a medication ontology and medication-related data aggregator created f
 
 Including data from DailyMed, FDA, RxNorm, Orange Book, and more!
 
-SageRx uses Airflow to schedule jobs to extract, load, and transform (using dbt) open drug data.
+SageRx uses Airflow to schedule jobs to extract, load, and transform (using DBT) open drug data.
 
 ![Airflow](docs/images/sagerx_airflow_example.png)
 
@@ -52,9 +52,11 @@ We would love to see you contribute to SageRx. Join our [Slack](https://join.sla
 - PgAdmin is hosted on `localhost:8002` or `0.0.0.0:8002`
   - Username/password = `sagerx` / `sagerx`
 
-### Using dbt
+### Using DBT
 
-On `docker-compose up` a dbt container will be created to be used for cli commands. To enter commands run `docker exec -it dbt /bin/bash`. This will place you into a bash session in the dbt container. Then you can run dbt commands as you normally would.
+On `docker-compose up` a DBT container will be created to be used for cli commands. To enter commands run `docker exec -it dbt /bin/bash`. This will place you into a bash session in the DBT container. Then you can run DBT commands as you normally would.
+
+To serve DBT documentation locally, enter the commands in the DBT container `dbt docs generate` then `dbt docs serve`. They should generate on `http://localhost:8080`
 
 ### Troubleshooting
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,8 @@ services:
     image: dbt
     container_name: dbt
     user: "${AIRFLOW_UID:-50000}:${AIRFLOW_GID:-0}"
+    ports:
+      - 8080:8080 # default dbt docs port
     volumes:
       - ./dbt:/dbt
     command: tail -f /dev/null
@@ -93,7 +95,7 @@ services:
     container_name: airflow-webserver
     command: webserver
     ports:
-      - 8001:8080
+      - 8001:8079
 
   airflow-scheduler:
     <<: *airflow-common


### PR DESCRIPTION
## Explanation
Update instructions around DBT documentation local hosting. Also open port 8080 (DBT documentation default port) to DBT container. This allows users to serve documentation locally and inspect changes when appropriate.

## Tests
1. What testing did you do?
dbt docs generate then dbt docs serve

1. Attach testing logs inside a summary block:

<details>
<summary>testing logs</summary>

```

```
</details>

