### PR TITLE
ATC to Product - Remove LIMIT 100

### DIFF
--- a/airflow/dags/rxclass/rxclass_atc_to_product_dag.py
+++ b/airflow/dags/rxclass/rxclass_atc_to_product_dag.py
@@ -36,7 +36,7 @@ def rxclass_atc_to_product():
         engine = pg_hook.get_sqlalchemy_engine()
 
         df = pd.read_sql(
-            "select distinct rxcui from datasource.rxnorm_rxnconso where tty in ('SCD','SBD','GPCK','BPCK') and sab = 'RXNORM' limit 100",
+            "select distinct rxcui from datasource.rxnorm_rxnconso where tty in ('SCD','SBD','GPCK','BPCK') and sab = 'RXNORM'",
             con=engine
         )
 

--- a/airflow/dags/rxclass/rxclass_atc_to_product_dag.py
+++ b/airflow/dags/rxclass/rxclass_atc_to_product_dag.py
@@ -59,7 +59,7 @@ def rxclass_atc_to_product():
             resp = jsonResponse["rxclassDrugInfoList"]["rxclassDrugInfo"][0]["rxclassMinConceptItem"]
             return resp
         except Exception as e:
-            print(e)
+            #print(e)
             return -1
 
     # Task to download data from web location

--- a/airflow/dags/rxclass/rxclass_atc_to_product_dag.py
+++ b/airflow/dags/rxclass/rxclass_atc_to_product_dag.py
@@ -72,7 +72,11 @@ def rxclass_atc_to_product():
         atcs = {}
         failed_atc = []
 
+        count = 0
         for rxcui in rxcui_list:
+            count += 1
+            if count % 1000 == 0:
+                print(f'MILESTONE {count}')
             sleep(0.1)
             atc = get_atc_from_rxcui(rxcui)
             if atc == -1:


### PR DESCRIPTION
## Explanation
The ATCPROD DAG was limited to 100 for testing purposes.  I removed the LIMIT 100 from the SQL to get RXCUIs.

Also it was missing a "MILESTONE" logging feature which emits a log every 1000 API calls (MILESTONE 1000, MILESTONE 2000, etc)..

Also I commented out the exception printing b/c it was noisy.  Should probably clean this up in the future if exceptions are important.

## Rationale
Wanted it to be useful out of the box - would be confusing if users had to remove the limit themselves.

## Tests
Currently running the DAG - MILESTONEs are showing up appropriately thus far.