### PR TITLE
Add RxNorm terms of service

### DIFF
--- a/airflow/dags/rxnorm/terms-of-service.md
+++ b/airflow/dags/rxnorm/terms-of-service.md
@@ -1,0 +1,7 @@
+# RxNorm Terms of Service
+
+```
+This product uses publicly available data courtesy of the U.S. National Library of Medicine (NLM), National Institutes of Health, Department of Health and Human Services; NLM is not responsible for the product and does not endorse or recommend this or any other product.
+```
+
+More information can be found at https://www.nlm.nih.gov/research/umls/rxnorm/docs/termsofservice.html.


### PR DESCRIPTION
Fixes #67

## Explanation
Added RxNorm terms of service.

## Rationale
UMLS requests per this website -> https://www.nlm.nih.gov/research/umls/rxnorm/docs/termsofservice.html.

## Tests
Looked at the markdown.