### PR TITLE
feat: update readme to reflect docker change

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ We would love to see you contribute to SageRx. Join our [Slack](https://join.sla
      - Windows users following the Docker Desktop install guide should have WSL 2 installed. You can open up command line, type `wsl` and then within WSL 2, you can enter `id -u` to see your UID.
    - `UMLS_API=<umls_api_key>` - if you want to use RxNorm, you need an API key from [UMLS](https://uts.nlm.nih.gov/uts/signup-login).
 4. Make sure Docker is installed
-5. Run `docker-compose up airflow-init`.
-6. Run `docker-compose up`.
+5. Run `docker compose up airflow-init`.
+6. Run `docker compose up`.
 
 > NOTE: if you have an [M1 Mac](https://stackoverflow.com/questions/62807717/how-can-i-solve-postgresql-scram-authentication-problem) `export DOCKER_DEFAULT_PLATFORM=linux/amd64`, and re-build your images
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,12 @@ We would love to see you contribute to SageRx. Join our [Slack](https://join.sla
      - Windows users following the Docker Desktop install guide should have WSL 2 installed. You can open up command line, type `wsl` and then within WSL 2, you can enter `id -u` to see your UID.
    - `UMLS_API=<umls_api_key>` - if you want to use RxNorm, you need an API key from [UMLS](https://uts.nlm.nih.gov/uts/signup-login).
 4. Make sure Docker is installed
-5. Run `docker compose up airflow-init`.
-6. Run `docker compose up`. 
+5. Run `docker-compose up airflow-init`.
+6. Run `docker-compose up`. 
 
 > NOTE: if you have an [M1 Mac](https://stackoverflow.com/questions/62807717/how-can-i-solve-postgresql-scram-authentication-problem) `export DOCKER_DEFAULT_PLATFORM=linux/amd64`, and re-build your images
+
+> NOTE 2: if you're running [WSL1/2](https://learn.microsoft.com/en-us/windows/wsl/about) you may need to use `docker compose` rather than `docker-compose` per [this](https://stackoverflow.com/questions/66514436/difference-between-docker-compose-and-docker-compose/66526176#66526176)
 
 ### Server URLs
 


### PR DESCRIPTION
Resolves Undocumented Issue

## Explanation
Switched the docker instructions from `docker-compose` to `docker compose` per updates here: https://stackoverflow.com/questions/66514436/difference-between-docker-compose-and-docker-compose

## Rationale
When running the docker commands per instructions in the root `sagerx` directory, the `docker-compose` commands would fail with an error "no such dockerfile". Dr. Google suggested this solution and it worked.

## Tests
1. What testing did you do?
Ran `docker compose up airflow-init` and it worked
Ran `docker-compose up airflow-init` and it didnt'


