### PR TITLE
updates to docker-compose to accomodate easy installation of new pack…

### DIFF
--- a/airflow/hidden_dags/cms_part_d_plans/cms_part_d_plans_dag.py
+++ b/airflow/hidden_dags/cms_part_d_plans/cms_part_d_plans_dag.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import os
 import pendulum
 # zipfile_deflate64 is needed likely because of how CMS zips these files
-import zipfile_deflate64 as zipfile # This package is not easily accessible in this context - consider an alternative
+import zipfile_deflate64 as zipfile # this package is not easily accessible in this context - consider an alternative
 
 from sagerx import create_path, get_dataset, read_sql_file, get_sql_list, alert_slack_channel
 

--- a/airflow/hidden_dags/cms_part_d_plans/cms_part_d_plans_dag.py
+++ b/airflow/hidden_dags/cms_part_d_plans/cms_part_d_plans_dag.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import os
 import pendulum
 # zipfile_deflate64 is needed likely because of how CMS zips these files
-import zipfile_deflate64 as zipfile
+import zipfile_deflate64 as zipfile # This package is not easily accessible in this context - consider an alternative
 
 from sagerx import create_path, get_dataset, read_sql_file, get_sql_list, alert_slack_channel
 

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,3 +1,4 @@
-apache-airflow[amazon]
+# Any change made here should accompany an increment 
+# to the image version on line 5 of docker-compose.yml
+
 dbt-postgres==1.4.1
-zipfile_deflate64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 x-airflow-common: &airflow-common
   build:
     context: ./airflow
-  image: sagerx_airflow
+  image: sagerx_airflow:v1 # Versioning allows a rebuild of docker image where necessary
   environment: &airflow-common-env
     AIRFLOW__CORE__EXECUTOR: LocalExecutor
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,12 @@ version: "3.8"
 x-airflow-common: &airflow-common
   build:
     context: ./airflow
-  image: sagerx_airflow:v1 # Versioning allows a rebuild of docker image where necessary
+  image: sagerx_airflow:v0.0.1 # versioning allows a rebuild of docker image where necessary
   environment: &airflow-common-env
     AIRFLOW__CORE__EXECUTOR: LocalExecutor
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "true"
     AIRFLOW__CORE__LOAD_EXAMPLES: "false"
-    #AIRFLOW__WEBSERVER__WEB_SERVER_MASTER_TIMEOUT: "300" #un-comment if gunicorn timeout reached
+    #AIRFLOW__WEBSERVER__WEB_SERVER_MASTER_TIMEOUT: "300" # un-comment if gunicorn timeout reached
     AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
     AIRFLOW_CONN_POSTGRES_DEFAULT: postgresql://sagerx:sagerx@postgres:5432/sagerx
     AIRFLOW_VAR_UMLS_API: ${UMLS_API}


### PR DESCRIPTION
…ages

Resolves N/A
This is an additional change to support installing new packages via requirements.txt implemented in a previous PR. I instituted arbitrary versioning of the docker image name in the docker-compose file so that when a change is made to the requirements, that person can increment the version and then anybody who pulls the code to their local branch and starts the pipeline in the normal way will get a freshly installed image with all the requirements in place. 
 
I also added some comments to the cms_part_d dag in the hidden folder. After a lot of fiddling, installing zipfile-deflate64 via the requirements file is failing - the wheel build is not succeeding more specifically. I believe the issue is related to need the build-essentials package, but that is installed via apt with sudo and we can't easily execute via sudo in the docker image. 

I would recommend we re-evaluate the need for that particular package and see if we can't make the normal python zipfile package do the work instead. 

## Explanation
[What did you change?]

## Rationale
[Why did you make the changes mentioned above? What alternatives did you consider?]

## Tests
1. What testing did you do?
1. Attach testing logs inside a summary block:

<details>
<summary>testing logs</summary>

```

```
</details>

