### PR TITLE
Two new product-related marts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+notebooks
 
 # Python files
 __pycache__

--- a/dbt/sagerx/models/marts/products/_products__models.yml
+++ b/dbt/sagerx/models/marts/products/_products__models.yml
@@ -1,0 +1,41 @@
+version: 2
+
+models:
+  - name: products
+    description: |
+      Product information including name, RXCUI, brand vs generic, ingredient, and dose form.
+
+      Data generally comes from RxNorm.
+    columns:
+      - name: brand_vs_generic
+        description: |
+          Simple (not comprehensive) brand vs generic flag.
+          
+          If TTY = SBD or BPCK, this will be brand.          
+          If TTY = SCD or GPCK, this will be generic.
+
+  - name: brand_products_with_related_ndcs
+    description: |
+      Brand Product RXCUI → Related Clinical Product RXCUI → NDCs related to that Clinical Product RXCUI → FDA Start Marketing Dates
+    columns:
+      - name: product_tty
+        description: Will always be SBD or BPCK since we are starting with brand products only.
+      - name: product_name
+        description: The name of the brand product we are starting from.
+      - name: ndc_product_tty
+        description: |
+          Could be SCD, SBD, GPCK, BPCK, or null.
+
+          A product related to the original brand product based on a clinical product identifier.
+
+          Example: starting with a product TTY / RXCUI of SBD 1000000, you could have a related ndc_product
+          of SBD 1000000 because that brand product relates to itself, as well as a related ndc_product of
+          SCD 999996 which is the generic version of the same product.
+
+          Can have duplicate RXCUIs if there are multiple NDCs related to that RXCUI.
+      - name: ndc
+        description: The NDC that relates to the ndc_product_rxcui.
+      - name: product_startmarketingdate
+        description: The start marketing date of the **product**. Can be different from that of the package.
+      - name: package_startmarketingdate
+        description: The start marketing date of the **package**. Can be different from that of the product.

--- a/dbt/sagerx/models/marts/products/brand_products_with_related_ndcs.sql
+++ b/dbt/sagerx/models/marts/products/brand_products_with_related_ndcs.sql
@@ -3,23 +3,31 @@ with brand_products as (
     where product_tty in ('SBD', 'BPCK') -- brand products only
 )
 
+, fda_ndcs as (
+    select * from {{ ref('stg_fda_ndc__ndcs') }}
+)
+
+, rxnorm_ndcs_to_products as (
+    select * from {{ ref('int_rxnorm_ndcs_to_products') }}
+)
+
 , map as (
-select
-    prod.product_tty
-    , prod.product_rxcui
-    , prod.product_name
-    , ndc.product_tty as ndc_product_tty
-    , ndc.product_rxcui as ndc_product_rxcui
-    , ndc.product_name as ndc_product_name
-    , ndc.ndc
-    , fda.product_startmarketingdate
-    , fda.package_startmarketingdate
-from brand_products prod
-left join sagerx_dev.int_rxnorm_ndcs_to_products ndc
-    on ndc.clinical_product_rxcui = prod.clinical_product_rxcui
-left join sagerx_dev.stg_fda_ndc__ndcs fda
-    on fda.ndc11 = ndc.ndc
-order by prod.product_rxcui
+    select
+        prod.product_tty
+        , prod.product_rxcui
+        , prod.product_name
+        , ndc.product_tty as ndc_product_tty
+        , ndc.product_rxcui as ndc_product_rxcui
+        , ndc.product_name as ndc_product_name
+        , ndc.ndc
+        , fda.product_startmarketingdate
+        , fda.package_startmarketingdate
+    from brand_products prod
+    left join rxnorm_ndcs_to_products ndc
+        on ndc.clinical_product_rxcui = prod.clinical_product_rxcui
+    left join fda_ndcs fda
+        on fda.ndc11 = ndc.ndc
+    order by prod.product_rxcui
 )
 
 select

--- a/dbt/sagerx/models/marts/products/brand_products_with_related_ndcs.sql
+++ b/dbt/sagerx/models/marts/products/brand_products_with_related_ndcs.sql
@@ -1,0 +1,27 @@
+with brand_products as (
+    select * from {{ ref('stg_rxnorm__products') }}
+    where product_tty in ('SBD', 'BPCK') -- brand products only
+)
+
+, map as (
+select
+    prod.product_tty
+    , prod.product_rxcui
+    , prod.product_name
+    , ndc.product_tty as ndc_product_tty
+    , ndc.product_rxcui as ndc_product_rxcui
+    , ndc.product_name as ndc_product_name
+    , ndc.ndc
+    , fda.product_startmarketingdate
+    , fda.package_startmarketingdate
+from brand_products prod
+left join sagerx_dev.int_rxnorm_ndcs_to_products ndc
+    on ndc.clinical_product_rxcui = prod.clinical_product_rxcui
+left join sagerx_dev.stg_fda_ndc__ndcs fda
+    on fda.ndc11 = ndc.ndc
+order by prod.product_rxcui
+)
+
+select
+    *
+from map

--- a/dbt/sagerx/models/marts/products/products.sql
+++ b/dbt/sagerx/models/marts/products/products.sql
@@ -1,0 +1,23 @@
+with rxnorm_products as (
+    select * from {{ ref('stg_rxnorm__products') }}
+)
+
+, rxnorm_clinical_products_to_ingredients as (
+    select * from {{ ref('int_rxnorm_clinical_products_to_ingredients') }}
+)
+
+select
+    product_rxcui
+    , product_name
+    , product_tty
+    , case
+        when product_tty in ('SBD', 'BPCK') then 'brand'
+        when product_tty in ('SCD', 'GPCK') then 'generic'
+        end as brand_vs_generic
+    , substring(product_name from '\[(.*)\]') as brand_name
+    , cping.ingredient_name
+    -- strength - couldn't easily get strength at this grain - can if needed
+    , cping.dose_form_name
+from rxnorm_products prod
+left join rxnorm_clinical_products_to_ingredients cping
+    on cping.clinical_product_rxcui = prod.clinical_product_rxcui

--- a/dbt/sagerx/models/staging/rxnorm/stg_rxnorm__products.sql
+++ b/dbt/sagerx/models/staging/rxnorm/stg_rxnorm__products.sql
@@ -1,0 +1,26 @@
+-- stg_rxnorm__products.sql
+
+with
+
+rcp as (
+
+    select * from {{ ref('stg_rxnorm__clinical_products') }}
+
+),
+
+rbp as (
+
+    select * from {{ ref('stg_rxnorm__brand_products') }}
+
+)
+
+select distinct
+    coalesce(rbp.rxcui, rcp.rxcui, null) as product_rxcui
+    , coalesce(rbp.name, rcp.name, null) as product_name
+    , coalesce(rbp.tty, rcp.tty, null) as product_tty
+    , rcp.rxcui as clinical_product_rxcui
+    , rcp.name as clinical_product_name
+    , rcp.tty as clinical_product_tty
+from rcp
+left join rbp
+    on rbp.clinical_product_rxcui = rcp.rxcui


### PR DESCRIPTION
Fixes #278 

## Explanation
Created a staging table to represent all RxNorm products.
Created a mart for product-level information - potentially useful for many applications in the future.
Created a specific mart for Brand Product RXCUI → Related Clinical Product RXCUI → NDCs related to that Clinical Product RXCUI → FDA Start Marketing Dates.

## Rationale
Two marts requested by customer.

Product mart could be used generally for other things.

## Additional Info
See documentation here

brand_products_with_related_ndcs
https://dbt.sagerx.io/#!/model/model.sagerx.brand_products_with_related_ndcs

products
https://dbt.sagerx.io/#!/model/model.sagerx.products