### PR TITLE
Add ATC codes to mart

### DIFF
--- a/dbt/sagerx/models/marts/classification/atc_codes_to_rxnorm_products.sql
+++ b/dbt/sagerx/models/marts/classification/atc_codes_to_rxnorm_products.sql
@@ -21,6 +21,10 @@ with atc_codes_to_rxnorm_product_rxcuis as (
 select distinct
 	atc_codes_to_rxnorm_product_rxcuis.rxcui
 	, rxnorm_product_rxcuis.str as rxnorm_description
+	, atc_codes.atc_1_code
+	, atc_codes.atc_2_code
+	, atc_codes.atc_3_code
+	, atc_codes.atc_4_code
 	, atc_codes.atc_1_name
 	, atc_codes.atc_2_name
 	, atc_codes.atc_3_name


### PR DESCRIPTION
## Explanation
Add ATC codes (not just names) to classification mart per request.

## Rationale
So codes can be used in analysis.

## Tests
Ran DAG and viewed results.