### PR TITLE
Fix to new RXCUI product mart

### DIFF
--- a/dbt/sagerx/models/intermediate/rxnorm/int_rxnorm_clinical_products_to_ingredients.sql
+++ b/dbt/sagerx/models/intermediate/rxnorm/int_rxnorm_clinical_products_to_ingredients.sql
@@ -36,15 +36,15 @@ select
     rcp.rxcui as clinical_product_rxcui
     , rcp.name as clinical_product_name
     , rcp.tty as clinical_product_tty
-    , rcpc.rxcui as clinical_product_component_rxcui
-    , rcpc.name as clinical_product_compnent_name
-    , rcpc.tty as clinical_product_component_tty
-    , rdf.rxcui as dose_form_rxcui
-    , rdf.name as dose_form_name
-    , rdf.tty as dose_form_tty
-    , ri.rxcui as ingredient_rxcui
-    , ri.name as ingredient_name
-    , ri.tty as ingredient_tty
+    , string_agg(rcpc.rxcui, ' | ') as clinical_product_component_rxcui
+    , string_agg(rcpc.name, ' | ') as clinical_product_compnent_name
+    , string_agg(rcpc.tty, ' | ') as clinical_product_component_tty
+    , string_agg(rdf.rxcui, ' | ') as dose_form_rxcui
+    , string_agg(rdf.name, ' | ') as dose_form_name
+    , string_agg(rdf.tty, ' | ') as dose_form_tty
+    , string_agg(ri.rxcui, ' | ') as ingredient_rxcui
+    , string_agg(ri.name, ' | ') as ingredient_name
+    , string_agg(ri.tty, ' | ') as ingredient_tty
     , rcp.active
     , rcp.prescribable        
 from rcp 
@@ -56,3 +56,10 @@ left join rdf
     on rcpc.dose_form_rxcui = rdf.rxcui 
 left join ri 
     on rcpc.ingredient_rxcui = ri.rxcui 
+group by
+    rcp.rxcui
+    , rcp.name
+    , rcp.tty
+    , rcp.active
+    , rcp.prescribable        
+

--- a/dbt/sagerx/models/marts/products/_products__models.yml
+++ b/dbt/sagerx/models/marts/products/_products__models.yml
@@ -7,6 +7,12 @@ models:
 
       Data generally comes from RxNorm.
     columns:
+      - name: product_rxcui
+        description: >
+          Product-level RxNorm RXCUI.
+        tests:
+          - unique
+          - not_null    
       - name: brand_vs_generic
         description: |
           Simple (not comprehensive) brand vs generic flag.

--- a/dbt/sagerx/models/marts/products/brand_products_with_related_ndcs.sql
+++ b/dbt/sagerx/models/marts/products/brand_products_with_related_ndcs.sql
@@ -1,6 +1,5 @@
 with brand_products as (
-    select * from {{ ref('stg_rxnorm__products') }}
-    where product_tty in ('SBD', 'BPCK') -- brand products only
+    select * from {{ ref('stg_rxnorm__brand_products') }}
 )
 
 , fda_ndcs as (
@@ -13,9 +12,9 @@ with brand_products as (
 
 , map as (
     select
-        prod.product_tty
-        , prod.product_rxcui
-        , prod.product_name
+        prod.tty as product_tty
+        , prod.rxcui as product_rxcui
+        , prod.name as product_name
         , ndc.product_tty as ndc_product_tty
         , ndc.product_rxcui as ndc_product_rxcui
         , ndc.product_name as ndc_product_name
@@ -27,7 +26,7 @@ with brand_products as (
         on ndc.clinical_product_rxcui = prod.clinical_product_rxcui
     left join fda_ndcs fda
         on fda.ndc11 = ndc.ndc
-    order by prod.product_rxcui
+    order by prod.rxcui
 )
 
 select

--- a/dbt/sagerx/models/marts/products/products.sql
+++ b/dbt/sagerx/models/marts/products/products.sql
@@ -7,14 +7,17 @@ with rxnorm_products as (
 )
 
 select
-    product_rxcui
-    , product_name
-    , product_tty
+    prod.rxcui as product_rxcui
+    , prod.name as product_name
+    , prod.tty as product_tty
     , case
-        when product_tty in ('SBD', 'BPCK') then 'brand'
-        when product_tty in ('SCD', 'GPCK') then 'generic'
+        when prod.tty in ('SBD', 'BPCK') then 'brand'
+        when prod.tty in ('SCD', 'GPCK') then 'generic'
         end as brand_vs_generic
-    , substring(product_name from '\[(.*)\]') as brand_name
+    , substring(prod.name from '\[(.*)\]') as brand_name
+    , cping.clinical_product_rxcui
+    , cping.clinical_product_name
+    , cping.clinical_product_tty
     , cping.ingredient_name
     -- strength - couldn't easily get strength at this grain - can if needed
     , cping.dose_form_name

--- a/dbt/sagerx/models/staging/rxnorm/stg_rxnorm__clinical_product_components.sql
+++ b/dbt/sagerx/models/staging/rxnorm/stg_rxnorm__clinical_product_components.sql
@@ -13,7 +13,8 @@ with cte as (
 			, ingredient.str as ingredient_name
 			, ingredient.tty as ingredient_tty
 		from sagerx_lake.rxnorm_rxnconso product_component
-		inner join sagerx_lake.rxnorm_rxnrel rxnrel on rxnrel.rxcui2 = product_component.rxcui and rxnrel.rela = 'has_ingredients'
+		inner join sagerx_lake.rxnorm_rxnrel rxnrel
+			on rxnrel.rxcui2 = product_component.rxcui and rxnrel.rela = 'has_ingredients'
 		inner join sagerx_lake.rxnorm_rxnconso ingredient
 			on rxnrel.rxcui1 = ingredient.rxcui
 			and ingredient.tty = 'MIN'
@@ -31,9 +32,12 @@ with cte as (
 			, ingredient.str as ingredient_name
 			, ingredient.tty as ingredient_tty
 		from sagerx_lake.rxnorm_rxnconso product_component
-		inner join sagerx_lake.rxnorm_rxnrel scdc_rxnrel on scdc_rxnrel.rxcui2 = product_component.rxcui and scdc_rxnrel.rela = 'consists_of'
-		inner join sagerx_lake.rxnorm_rxnconso scdc on scdc_rxnrel.rxcui1 = scdc.rxcui
-		inner join sagerx_lake.rxnorm_rxnrel ingredient_rxnrel on ingredient_rxnrel.rxcui2 = scdc.rxcui and ingredient_rxnrel.rela = 'has_ingredient'
+		inner join sagerx_lake.rxnorm_rxnrel scdc_rxnrel
+			on scdc_rxnrel.rxcui2 = product_component.rxcui and scdc_rxnrel.rela = 'consists_of'
+		inner join sagerx_lake.rxnorm_rxnconso scdc
+			on scdc_rxnrel.rxcui1 = scdc.rxcui
+		inner join sagerx_lake.rxnorm_rxnrel ingredient_rxnrel
+			on ingredient_rxnrel.rxcui2 = scdc.rxcui and ingredient_rxnrel.rela = 'has_ingredient'
 		inner join sagerx_lake.rxnorm_rxnconso ingredient
 			on ingredient_rxnrel.rxcui1 = ingredient.rxcui
 			and ingredient.tty = 'IN'

--- a/dbt/sagerx/models/staging/rxnorm/stg_rxnorm__products.sql
+++ b/dbt/sagerx/models/staging/rxnorm/stg_rxnorm__products.sql
@@ -1,5 +1,28 @@
 -- stg_rxnorm__products.sql
 
+select
+	product.rxcui as rxcui
+	, product.str as name
+	, product.tty as tty
+    , case
+        when brand_product.rxcui is not null then brand_product.clinical_product_rxcui
+        else product.rxcui
+        end as clinical_product_rxcui
+	, case
+        when product.suppress = 'N' then true
+        else false
+        end as active
+	, case 
+        when product.cvf = '4096' then true 
+        else false
+        end as prescribable
+from {{ source('rxnorm', 'rxnorm_rxnconso') }} product
+left join {{ ref('stg_rxnorm__brand_products') }} brand_product
+    on product.rxcui = brand_product.rxcui
+where product.tty in('SCD', 'GPCK', 'SBD', 'BPCK')
+	and product.sab = 'RXNORM'
+
+/*
 with
 
 rcp as (
@@ -24,3 +47,4 @@ select distinct
 from rcp
 left join rbp
     on rbp.clinical_product_rxcui = rcp.rxcui
+*/


### PR DESCRIPTION
## Explanation
It was identified that there were duplicate rows and not great cross-match between ndc mart and RXCUI product mart.

I found an oversight where I was only including a subset of all product RXCUIs and fixed.

I pipe-delimited " | " product info - mostly (entirely?) GPCK/BPCK products that had multiple products and ingredients within them and sometimes different dose forms, etc.  Need to come up with a better solution to this to maintain granularity, but this will do for now.

Also added a dbt test to ensure product RXCUIs are unique in the products mart.

## Rationale
Customer request - need to maintain granularity of product RXCUI.

## Tests
Ran dbt build for mart and dependencies.
No duplicate product RXCUIs in products mart.
Joined to ndc table and got 100% match.