### PR TITLE
Add new marts - excipients, products, and NDC sources

### DIFF
--- a/airflow/dags/build_marts/dag.py
+++ b/airflow/dags/build_marts/dag.py
@@ -60,5 +60,8 @@ with dag:
         atc_subprocess = SubprocessHook()
         result = atc_subprocess.run_command(['dbt', 'run', '--select', '+models/marts/classification'], cwd='/dbt/sagerx')
         print("Result from dbt:", result)
+        products_subprocess = SubprocessHook()
+        result = products_subprocess.run_command(['dbt', 'run', '--select', '+models/marts/products'], cwd='/dbt/sagerx')
+        print("Result from dbt:", result)
 
     execute_external_dag_list() >> transform_tasks()

--- a/airflow/dags/export_marts/dag.py
+++ b/airflow/dags/export_marts/dag.py
@@ -26,7 +26,7 @@ with dag:
     def export_marts():
         pg_hook = PostgresHook(postgres_conn_id="postgres_default")
         engine = pg_hook.get_sqlalchemy_engine()
-        marts_list = ["all_ndc_descriptions","atc_codes_to_rxnorm_products"]
+        marts_list = ["all_ndc_descriptions","atc_codes_to_rxnorm_products","all_ndcs_to_sources","products_to_inactive_ingredients","products","brand_products_with_related_ndcs"]
         mart_dfs={}
         with engine.connect() as connection:
             for mart in marts_list:

--- a/dbt/sagerx/models/marts/ndc/all_ndcs_to_sources.sql
+++ b/dbt/sagerx/models/marts/ndc/all_ndcs_to_sources.sql
@@ -89,4 +89,16 @@ with rxnorm_historical_ndcs as
     where ndc is not null
 )
 
-select * from all_not_null_ndcs_to_sources
+, all_ndc_descriptions as (
+    select * from {{ ref('all_ndc_descriptions') }}
+)
+
+, all_ndcs_with_descriptions_to_sources as (
+    select
+        all_not_null_ndcs_to_sources.*
+    from all_not_null_ndcs_to_sources
+    inner join all_ndc_descriptions
+        on all_ndc_descriptions.ndc = all_not_null_ndcs_to_sources.ndc
+)
+
+select * from all_ndcs_with_descriptions_to_sources

--- a/dbt/sagerx/models/marts/products/products_to_inactive_ingredients.sql
+++ b/dbt/sagerx/models/marts/products/products_to_inactive_ingredients.sql
@@ -1,0 +1,7 @@
+-- products_to_inactive_ingredients.sql
+
+with products_to_inactive_ingredients as (
+    select * from {{ ref('int_mthspl_products_to_inactive_ingredients') }}
+)
+
+select * from products_to_inactive_ingredients


### PR DESCRIPTION

## Explanation
Added all_ndcs_to_sources as a mart and limited it to only NDCs in the existing NDC description mart so the row counts match.
Added a product to inactive ingredient mart which just pulls from the existing mthspl intermediate table.
Added the product marts I've been working on per request from customer.

## Rationale
To make it easier to use as marts when ready.

## Tests
Ran build_marts and export_marts and checked AWS s3 bucket.