### PR TITLE
Intermediate models as tables

### DIFF
--- a/dbt/sagerx/dbt_project.yml
+++ b/dbt/sagerx/dbt_project.yml
@@ -35,7 +35,7 @@ models:
       +materialized: view
     intermediate:
       +schema: sagerx
-      +materialized: view
+      +materialized: table
     marts:
       +schema: sagerx
       +materialized: table


### PR DESCRIPTION
## Explanation
Sets intermediate models to materialize as tables (vs views).

## Rationale
dbt mart models are made up of complex logic that should be captured in the intermediate models. The issues already that we ran into (issue https://github.com/coderxio/sagerx/issues/270 ) was that performing these aggregations for each query took 10+ minutes. Therefore, bringing this aggregation into a separated intermediate model to be materialized as a table is a good solution. The materialization of these intermediate tables can take awhile but will significantly speed up queries.

Additional work can be done to optimize the queries that build out intermediate models in the future.

## Tests
1. What testing did you do?
dbt run --full-refresh
