### PR TITLE
FDA Cleanup

### DIFF
--- a/airflow/dags/common_dag_tasks.py
+++ b/airflow/dags/common_dag_tasks.py
@@ -107,7 +107,13 @@ def extract(dag_id,url) -> str:
 def transform(dag_id, models_subdir='staging',task_id="") -> None:
     # Task to transform data using dbt
     from airflow.hooks.subprocess import SubprocessHook
+    from airflow.exceptions import AirflowException
 
     subprocess = SubprocessHook()
     result = subprocess.run_command(['docker', 'exec', 'dbt','dbt', 'run', '--select', f'models/{models_subdir}/{dag_id}'], cwd='/dbt/sagerx')
+<<<<<<< HEAD
+=======
+    if result.exit_code != 0:
+            raise AirflowException(f"Command failed with return code {result.exit_code}: {result.output}")
+>>>>>>> d972c97 (init fba cleanup)
     print("Result from dbt:", result)

--- a/airflow/dags/common_dag_tasks.py
+++ b/airflow/dags/common_dag_tasks.py
@@ -111,9 +111,6 @@ def transform(dag_id, models_subdir='staging',task_id="") -> None:
 
     subprocess = SubprocessHook()
     result = subprocess.run_command(['docker', 'exec', 'dbt','dbt', 'run', '--select', f'models/{models_subdir}/{dag_id}'], cwd='/dbt/sagerx')
-<<<<<<< HEAD
-=======
     if result.exit_code != 0:
             raise AirflowException(f"Command failed with return code {result.exit_code}: {result.output}")
->>>>>>> d972c97 (init fba cleanup)
     print("Result from dbt:", result)

--- a/dbt/sagerx/models/staging/fda_excluded/_fda_excluded__models.yml
+++ b/dbt/sagerx/models/staging/fda_excluded/_fda_excluded__models.yml
@@ -6,7 +6,7 @@ models:
     columns:
       - name: ndc11
         description: "The ndcpackagecode field, normalized to a NDC11 format."
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: productid

--- a/dbt/sagerx/models/staging/fda_excluded/stg_fda_excluded__classes.sql
+++ b/dbt/sagerx/models/staging/fda_excluded/stg_fda_excluded__classes.sql
@@ -1,19 +1,24 @@
 -- stg_fda_excluded__classes.sql
-
 with
 
 product as (
-    
     select * from {{ source('fda_excluded', 'fda_excluded_product') }}
+)
 
+, pharm_classes_array as (
+	select 
+		product.productid
+		, token
+		, row_number() over (partition by product.productid order by token desc) as class_line
+	from product, unnest(string_to_array(product.pharm_classes, ',')) as token
 )
 
 select
-	z.productid
-	, row_number() over (partition by z.productid order by z.token desc) as class_line
-	, trim(left(z.token, position('[' in z.token) -1 )) as class_name
-    , substring(z.token, '\[(.+)\]') as class_type
-from (select distinct product.productid
-	, product.pharm_classes
-	, s.token
-	from product, unnest(string_to_array(product.pharm_classes, ',')) s(token)) z
+	classes.productid
+	, classes.class_line
+	, trim(left(classes.token, position('[' in classes.token) -1 )) as class_name
+	, substring(classes.token, '\[(.+)\]') as class_type
+from pharm_classes_array classes
+order by
+	productid
+	, class_line

--- a/dbt/sagerx/models/staging/fda_excluded/stg_fda_excluded__substances.sql
+++ b/dbt/sagerx/models/staging/fda_excluded/stg_fda_excluded__substances.sql
@@ -2,18 +2,47 @@
 
 with
 
-product as (
-    
+product as (    
     select * from {{ source('fda_excluded', 'fda_excluded_product') }}
-
 )
 
-select distinct
-	product.productid
-	, row_number() over (partition by product.productid) as substance_line
-	, arr.*
-from product
-	, unnest(string_to_array(product.substancename, '; ')
-		, string_to_array(product.active_numerator_strength, '; ')
-		, string_to_array(product.active_ingred_unit, '; ')
-	) arr(substancename, active_numerator_strength, active_ingred_unit)
+, substancename_array as (
+	select
+		productid
+		, substance
+		, row_number() over(partition by productid) as substance_line
+	from product, unnest(string_to_array(substancename, '; ')) as substance
+)
+
+, strength_array as (
+	select
+		productid
+		, strength
+		, row_number() over(partition by productid) as strength_line
+	from product, unnest(string_to_array(active_numerator_strength, '; ')) as strength
+)
+
+, unit_array as (
+	select
+		productid
+		, unit
+		, row_number() over(partition by productid) as unit_line
+	from product, unnest(string_to_array(active_ingred_unit, '; ')) as unit
+)
+
+select
+	substance.productid
+	, substance.substance_line
+	, substance.substance as substancename
+	, strength.strength as active_numerator_strength
+	, unit.unit as active_ingred_unit
+from substancename_array substance
+inner join strength_array strength
+	on strength.productid = substance.productid
+	and strength.strength_line = substance.substance_line
+inner join unit_array unit
+	on unit.productid = substance.productid
+	and unit.unit_line = substance.substance_line
+order by
+	productid
+	, substance_line

--- a/dbt/sagerx/models/staging/fda_ndc/_fda_ndc__models.yml
+++ b/dbt/sagerx/models/staging/fda_ndc/_fda_ndc__models.yml
@@ -6,7 +6,7 @@ models:
     columns:
       - name: ndc11
         description: "The ndcpackagecode field, normalized to a NDC11 format."
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: productid

--- a/dbt/sagerx/models/staging/fda_ndc/stg_fda_ndc__classes.sql
+++ b/dbt/sagerx/models/staging/fda_ndc/stg_fda_ndc__classes.sql
@@ -2,18 +2,24 @@
 
 with
 
-product as (
-    
+product as (    
     select * from {{ source('fda_ndc', 'fda_ndc_product') }}
+)
 
+, pharm_classes_array as (
+	select 
+		product.productid
+		, token
+		, row_number() over (partition by product.productid order by token desc) as class_line
+	from product, unnest(string_to_array(product.pharm_classes, ',')) as token
 )
 
 select
-	z.productid
-	, row_number() over (partition by z.productid order by z.token desc) as class_line
-	, trim(left(z.token, position('[' in z.token) -1 )) as class_name
-    , substring(z.token, '\[(.+)\]') as class_type
-from (select distinct product.productid
-	, product.pharm_classes
-	, s.token
-	from product, unnest(string_to_array(product.pharm_classes, ',')) s(token)) z
+	classes.productid
+	, classes.class_line
+	, trim(left(classes.token, position('[' in classes.token) -1 )) as class_name
+	, substring(classes.token, '\[(.+)\]') as class_type
+from pharm_classes_array classes
+order by
+	productid
+	, class_line

--- a/dbt/sagerx/models/staging/fda_ndc/stg_fda_ndc__substances.sql
+++ b/dbt/sagerx/models/staging/fda_ndc/stg_fda_ndc__substances.sql
@@ -3,17 +3,46 @@
 with
 
 product as (
-    
     select * from {{ source('fda_ndc', 'fda_ndc_product') }}
-
 )
 
-select distinct
-	product.productid
-	, row_number() over (partition by product.productid) as substance_line
-	, arr.*
-from product
-	, unnest(string_to_array(product.substancename, '; ')
-		, string_to_array(product.active_numerator_strength, '; ')
-		, string_to_array(product.active_ingred_unit, '; ')
-	) arr(substancename, active_numerator_strength, active_ingred_unit)
+, substancename_array as (
+	select
+		productid
+		, substance
+		, row_number() over(partition by productid) as substance_line
+	from product, unnest(string_to_array(substancename, '; ')) as substance
+)
+
+, strength_array as (
+	select
+		productid
+		, strength
+		, row_number() over(partition by productid) as strength_line
+	from product, unnest(string_to_array(active_numerator_strength, '; ')) as strength
+)
+
+, unit_array as (
+	select
+		productid
+		, unit
+		, row_number() over(partition by productid) as unit_line
+	from product, unnest(string_to_array(active_ingred_unit, '; ')) as unit
+)
+
+select
+	substance.productid
+	, substance.substance_line
+	, substance.substance as substancename
+	, strength.strength as active_numerator_strength
+	, unit.unit as active_ingred_unit
+from substancename_array substance
+inner join strength_array strength
+	on strength.productid = substance.productid
+	and strength.strength_line = substance.substance_line
+inner join unit_array unit
+	on unit.productid = substance.productid
+	and unit.unit_line = substance.substance_line
+order by
+	productid
+	, substance_line

--- a/dbt/sagerx/models/staging/fda_unfinished/_fda_unfinished__models.yml
+++ b/dbt/sagerx/models/staging/fda_unfinished/_fda_unfinished__models.yml
@@ -6,7 +6,7 @@ models:
     columns:
       - name: ndc11
         description: "The ndcpackagecode field, normalized to a NDC11 format."
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: productid

--- a/dbt/sagerx/models/staging/fda_unfinished/stg_fda_unfinished__substances.sql
+++ b/dbt/sagerx/models/staging/fda_unfinished/stg_fda_unfinished__substances.sql
@@ -2,18 +2,47 @@
 
 with
 
-product as (
-    
+product as (    
     select * from {{ source('fda_unfinished', 'fda_unfinished_product') }}
-
 )
 
-select distinct
-    product.productid
-    , row_number() over (partition by product.productid) as substance_line
-    , arr.*
-from product
-    , unnest(string_to_array(product.substancename, '; ')
-            ,string_to_array(product.active_numerator_strength, '; ')
-            ,string_to_array(product.active_ingred_unit, '; ')
-        ) arr(substancename, active_numerator_strength, active_ingred_unit)
+, substancename_array as (
+	select
+		productid
+		, substance
+		, row_number() over(partition by productid) as substance_line
+	from product, unnest(string_to_array(substancename, '; ')) as substance
+)
+
+, strength_array as (
+	select
+		productid
+		, strength
+		, row_number() over(partition by productid) as strength_line
+	from product, unnest(string_to_array(active_numerator_strength, '; ')) as strength
+)
+
+, unit_array as (
+	select
+		productid
+		, unit
+		, row_number() over(partition by productid) as unit_line
+	from product, unnest(string_to_array(active_ingred_unit, '; ')) as unit
+)
+
+select
+	substance.productid
+	, substance.substance_line
+	, substance.substance as substancename
+	, strength.strength as active_numerator_strength
+	, unit.unit as active_ingred_unit
+from substancename_array substance
+inner join strength_array strength
+	on strength.productid = substance.productid
+	and strength.strength_line = substance.substance_line
+inner join unit_array unit
+	on unit.productid = substance.productid
+	and unit.unit_line = substance.substance_line
+order by
+	productid
+	, substance_line


### PR DESCRIPTION
## Explanation
- Cleans up the dbt for some of the FDA DAGs 
   - Removes the SELECT * from the SQL which makes it hard to understand what tables are being captured 
   - Moves some of the complicated SQL logic into CTEs to make it more understandable and maintainable 
- replaces tests to data_tests as is recommended by dbt now
- adds airflow exception to the transform task capturing errors and incomplete runs

## Rationale
Making the SQL understandable and maintainable is important  

## Tests
1. What testing did you do?
   - ran each DAG and then queries a staged table 


