### PR TITLE
Create SQL indexes and method for creating df indexes

### DIFF
--- a/airflow/dags/fda_excluded/load_package.sql
+++ b/airflow/dags/fda_excluded/load_package.sql
@@ -14,3 +14,6 @@ sample_package      TEXT
 
 COPY sagerx_lake.fda_excluded_package
 FROM '{data_path}/Packages_excluded.txt' DELIMITER E'\t' CSV HEADER ENCODING 'WIN1252';;
+
+CREATE INDEX IF NOT EXISTS x_productid
+ON sagerx_lake.fda_excluded_package(productid);

--- a/airflow/dags/fda_excluded/load_product.sql
+++ b/airflow/dags/fda_excluded/load_product.sql
@@ -27,3 +27,6 @@ PRIMARY KEY (productid)
 
 COPY sagerx_lake.fda_excluded_product
 FROM '{data_path}/Products_excluded.txt' DELIMITER E'\t' CSV HEADER ENCODING 'WIN1252';;
+
+CREATE INDEX IF NOT EXISTS x_productid
+ON sagerx_lake.fda_excluded_product(productid);

--- a/airflow/dags/fda_ndc/load_package.sql
+++ b/airflow/dags/fda_ndc/load_package.sql
@@ -14,3 +14,6 @@ sample_package      TEXT
 
 COPY sagerx_lake.fda_ndc_package
 FROM '{data_path}/package.txt' DELIMITER E'\t' CSV HEADER ENCODING 'WIN1252';;
+
+CREATE INDEX IF NOT EXISTS x_productid
+ON sagerx_lake.fda_ndc_package(productid);

--- a/airflow/dags/fda_ndc/load_product.sql
+++ b/airflow/dags/fda_ndc/load_product.sql
@@ -27,3 +27,6 @@ PRIMARY KEY (productid)
 
 COPY sagerx_lake.fda_ndc_product
 FROM '{data_path}/product.txt' DELIMITER E'\t' CSV HEADER ENCODING 'WIN1252';;
+
+CREATE INDEX IF NOT EXISTS x_productid
+ON sagerx_lake.fda_ndc_product(productid);

--- a/airflow/dags/fda_unfinished/load_package.sql
+++ b/airflow/dags/fda_unfinished/load_package.sql
@@ -12,3 +12,6 @@ endmarketingdate    TEXT
 
 COPY sagerx_lake.fda_unfinished_package
 FROM '{data_path}/unfinished_package.txt' DELIMITER E'\t' CSV HEADER ENCODING 'WIN1252';
+
+CREATE INDEX IF NOT EXISTS x_productid
+ON sagerx_lake.fda_unfinished_package(productid);

--- a/airflow/dags/fda_unfinished/load_product.sql
+++ b/airflow/dags/fda_unfinished/load_product.sql
@@ -19,6 +19,7 @@ listing_record_certified_through    TEXT,
 PRIMARY KEY (productid)
 );
 
-COPY sagerx_lake.fda_unfinished_product
-FROM '{data_path}/unfinished_product.txt'
-DELIMITER E'\t' CSV HEADER ENCODING 'WIN1252';
+COPY sagerx_lake.fda_unfinished_product FROM '{data_path}/unfinished_product.txt' DELIMITER E'\t' CSV HEADER ENCODING 'WIN1252';
+
+CREATE INDEX IF NOT EXISTS x_productid
+ON sagerx_lake.fda_unfinished_product(productid);

--- a/airflow/dags/rxnorm_historical/dag_tasks.py
+++ b/airflow/dags/rxnorm_historical/dag_tasks.py
@@ -47,4 +47,4 @@ def extract_ndc(ndc_list:list)->None:
         df['rxcui'] = rxcui
         dfs.append(df)
 
-    load_df_to_pg(pd.concat(dfs),"sagerx_lake","rxnorm_historical","replace",index=False)
+    load_df_to_pg(pd.concat(dfs),"sagerx_lake","rxnorm_historical","replace",index=False, create_index=True, index_columns=['ndc','end_date'])

--- a/airflow/dags/sagerx.py
+++ b/airflow/dags/sagerx.py
@@ -149,7 +149,8 @@ def alert_slack_channel(context):
             message=msg,
         ).execute(context=None)
 
-def load_df_to_pg(df,schema_name:str,table_name:str,if_exists:str,dtype_name:str="",index:bool=True) -> None:
+def load_df_to_pg(df,schema_name:str,table_name:str,if_exists:str,dtype_name:str="",index:bool=True, 
+                  create_index: bool = False, index_columns: list = None) -> None:
     from airflow.hooks.postgres_hook import PostgresHook
     import sqlalchemy
 
@@ -158,6 +159,15 @@ def load_df_to_pg(df,schema_name:str,table_name:str,if_exists:str,dtype_name:str
 
     if if_exists == "replace":
         engine.execute(f'DROP TABLE IF EXISTS {schema_name}.{table_name} cascade')
+    
+    # Create index before loading data if specified
+    if create_index and index_columns:
+        if len(index_columns) == 1:
+            engine.execute(f'CREATE INDEX IF NOT EXISTS idx_{table_name}_{index_columns[0]} ON {schema_name}.{table_name} ({index_columns[0]})')
+        else:
+            columns_str = ', '.join(index_columns)
+            engine.execute(f'CREATE INDEX IF NOT EXISTS idx_{table_name}_{"_".join(index_columns)} ON {schema_name}.{table_name} ({columns_str})')
+
 
     if dtype_name:
         dtype = {dtype_name:sqlalchemy.types.JSON}


### PR DESCRIPTION
## Explanation
@leemlb06pmi and @Komal77rao did this work.

Created indexes for FDA DAGs that just use SQL to load data.

Updated `load_df_to_pg` method in `sagerx.py` to handle creation of indexes for dataframe-based data loads.

## Rationale
Improve performance / efficiency by adding indexes.

## Tests
