### PR TITLE
Change transform to list

### DIFF
--- a/airflow/dags/build_marts/dag.py
+++ b/airflow/dags/build_marts/dag.py
@@ -55,8 +55,8 @@ with dag:
     # Once DBT freshness metrics are implemented, this task can be updated
     @task
     def transform_tasks():
-        run_subprocess_command(['dbt', 'run', '--select', '+models/marts/ndc'], cwd='/dbt/sagerx')
-        run_subprocess_command(['dbt', 'run', '--select', '+models/marts/classification'], cwd='/dbt/sagerx')
-        run_subprocess_command(['dbt', 'run', '--select', '+models/marts/products'], cwd='/dbt/sagerx')
+        run_subprocess_command(['docker', 'exec', 'dbt', 'dbt', 'run', '--select', '+models/marts/ndc'], cwd='/dbt/sagerx')
+        run_subprocess_command(['docker', 'exec', 'dbt', 'dbt', 'run', '--select', '+models/marts/classification'], cwd='/dbt/sagerx')
+        run_subprocess_command(['docker', 'exec', 'dbt', 'dbt', 'run', '--select', '+models/marts/products'], cwd='/dbt/sagerx')
 
     execute_external_dag_list() >> transform_tasks()

--- a/airflow/dags/common_dag_tasks.py
+++ b/airflow/dags/common_dag_tasks.py
@@ -116,10 +116,12 @@ def extract(dag_id,url) -> str:
 
 
 @task
-def transform(dag_id, models_subdir='staging',task_id="") -> None:
+def transform(dag_id, models_subdir=['staging'], task_id="") -> None:
     # Task to transform data using dbt
+    models = [f'models/{model_subdir}/{dag_id}' for model_subdir in models_subdir]
+    command = ['docker', 'exec', 'dbt', 'dbt', 'run', '--select'] + models
 
     run_subprocess_command(
-        command=['docker', 'exec', 'dbt','dbt', 'run', '--select', f'models/{models_subdir}/{dag_id}'],
+        command=command,
         cwd='/dbt/sagerx'
     )

--- a/airflow/dags/nadac/dag.py
+++ b/airflow/dags/nadac/dag.py
@@ -8,7 +8,7 @@ from airflow.decorators import dag, task
 
 from airflow.providers.postgres.operators.postgres import PostgresOperator
 
-from common_dag_tasks import run_subprocess_command
+from common_dag_tasks import transform
 
 starting_date = pendulum.parse("2013-12-01")
 
@@ -77,11 +77,8 @@ def nadac():
             )
         )
 
-    # Task to transform data using dbt
-    @task
-    def transform():
-        run_subprocess_command(['dbt', 'run', '--select', 'models/staging/nadac'], cwd='/dbt/sagerx')
+    transform_task = transform(dag_id)
 
-    extract() >> load >> transform()
+    extract() >> load >> transform_task
 
 nadac()

--- a/airflow/dags/rxnorm/dag.py
+++ b/airflow/dags/rxnorm/dag.py
@@ -9,7 +9,7 @@ from airflow.operators.python import get_current_context
 from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.hooks.postgres_hook import PostgresHook
 
-from common_dag_tasks import run_subprocess_command
+from common_dag_tasks import transform
 
 
 @dag(
@@ -73,11 +73,8 @@ def rxnorm():
             )
         )
 
-    # Task to transform data using dbt
-    @task
-    def transform():
-        run_subprocess_command(['dbt', 'run', '--select', 'models/staging/rxnorm', 'models/intermediate/rxnorm'], cwd='/dbt/sagerx')
+    transform_task = transform(dag_id, models_subdir=['staging', 'intermediate'])
 
-    extract(get_st(get_tgt())) >> load >> transform()
+    extract(get_st(get_tgt())) >> load >> transform_task
 
 rxnorm()


### PR DESCRIPTION
## Explanation
Changed the common transform task to handle multiple levels of transformation (staging alone or staging and intermediate). I still need to figure out the best way to handle marts because we use the + character in front of the model - I believe to indicate we want dbt to run all dependent models for these(?).  Either way, I left the build_marts tasks alone for now - hardcoded into the task.

## Rationale
Currently, you can only transform data into staging models because we didn't account for intermediate models. This allows flexibility to do either or both.

## Tests
Tested running DAGs that only had staging models and also ones that had both staging and intermediate models.