### PR TITLE
Fix index bug

### DIFF
--- a/airflow/dags/sagerx.py
+++ b/airflow/dags/sagerx.py
@@ -178,8 +178,8 @@ def load_df_to_pg(df,schema_name:str,table_name:str,if_exists:str,dtype_name:str
     )
 
     if create_index and index_columns:
-            columns_str = ', '.join(index_columns)
-            engine.execute(f'CREATE INDEX IF NOT EXISTS idx_{table_name}_{"_".join(index_columns)} ON {schema_name}.{table_name} ({columns_str})')
+        columns_str = ', '.join(index_columns)
+        engine.execute(f'CREATE INDEX IF NOT EXISTS idx_{table_name}_{"_".join(index_columns)} ON {schema_name}.{table_name} ({columns_str})')
 
 def run_query_to_df(query:str) -> pd.DataFrame:
     from airflow.hooks.postgres_hook import PostgresHook

--- a/airflow/dags/sagerx.py
+++ b/airflow/dags/sagerx.py
@@ -158,18 +158,6 @@ def load_df_to_pg(df,schema_name:str,table_name:str,if_exists:str,dtype_name:str
     pg_hook = PostgresHook(postgres_conn_id="postgres_default")
     engine = pg_hook.get_sqlalchemy_engine()
 
-    if if_exists == "replace":
-        engine.execute(f'DROP TABLE IF EXISTS {schema_name}.{table_name} cascade')
-    
-    # Create index before loading data if specified
-    if create_index and index_columns:
-        if len(index_columns) == 1:
-            engine.execute(f'CREATE INDEX IF NOT EXISTS idx_{table_name}_{index_columns[0]} ON {schema_name}.{table_name} ({index_columns[0]})')
-        else:
-            columns_str = ', '.join(index_columns)
-            engine.execute(f'CREATE INDEX IF NOT EXISTS idx_{table_name}_{"_".join(index_columns)} ON {schema_name}.{table_name} ({columns_str})')
-
-
     if dtype_name:
         dtype = {dtype_name:sqlalchemy.types.JSON}
     else:
@@ -188,6 +176,10 @@ def load_df_to_pg(df,schema_name:str,table_name:str,if_exists:str,dtype_name:str
         dtype=dtype,
         index=index
     )
+
+    if create_index and index_columns:
+            columns_str = ', '.join(index_columns)
+            engine.execute(f'CREATE INDEX IF NOT EXISTS idx_{table_name}_{"_".join(index_columns)} ON {schema_name}.{table_name} ({columns_str})')
 
 def run_query_to_df(query:str) -> pd.DataFrame:
     from airflow.hooks.postgres_hook import PostgresHook


### PR DESCRIPTION
Resolves #314 

## Explanation
Moved the index creation below the df_to_sql call.  Seems to have fixed the bug.

Also removed the distinction between single and multiple columns in the params as join won't add a comma if there's only one item in the list.

## Rationale
This kept erroring out at the very end of my rxnorm_historical runs which take an hour which was very frustrating. I think this fixes it, but not sure if doing it this way introduces other issues.

## Tests
Ran rxnorm_historical on only BPCK TTYs (to reduce run time).  Errored out like normal without my change. Then I ran it with no existing rxnorm_historical table and it worked and created the index.  Then I ran it again with the rxnorm_historical table existing and it worked and created the index.