### PR TITLE
Remove errant string in rxnorm

### DIFF
--- a/airflow/dags/rxnorm/dag.py
+++ b/airflow/dags/rxnorm/dag.py
@@ -73,7 +73,6 @@ def rxnorm():
             )
         )
 
-<<<<<< jrlegrand/transform-update
     transform_task = transform(dag_id, models_subdir=['staging', 'intermediate'])
 
     extract(get_st(get_tgt())) >> load >> transform_task


### PR DESCRIPTION
Resolves #ISSUE NUMBER

## Explanation
There was a line left over from a merge in the rxnorm dag.py file that was causing errors. Removed this line

## Rationale
I really wanted things to work :)

## Tests
1. What testing did you do?
Changed, ran DAG without issue, no errors.
1. Attach testing logs inside a summary block:

<details>
<summary>testing logs</summary>

```

```
</details>

