### PR TITLE
fix seeding of `usp_preservatives` table

### DIFF
--- a/airflow/dags/build_marts/dag.py
+++ b/airflow/dags/build_marts/dag.py
@@ -55,6 +55,7 @@ with dag:
     # Once DBT freshness metrics are implemented, this task can be updated
     @task
     def transform_tasks():
+        run_subprocess_command(['docker', 'exec', 'dbt', 'dbt', 'seed'], cwd='/dbt/sagerx')
         run_subprocess_command(['docker', 'exec', 'dbt', 'dbt', 'run', '--select', '+models/marts/ndc'], cwd='/dbt/sagerx')
         run_subprocess_command(['docker', 'exec', 'dbt', 'dbt', 'run', '--select', '+models/marts/classification'], cwd='/dbt/sagerx')
         run_subprocess_command(['docker', 'exec', 'dbt', 'dbt', 'run', '--select', '+models/marts/products'], cwd='/dbt/sagerx')


### PR DESCRIPTION
## Explanation
The `build_marts` DAG in Airflow was failing. The log indicated that an error was occuring in the `products_to_inactive_ingredients` model:

> [2025-01-13, 16:31:05 PST] {subprocess.py:93} INFO - [0m00:31:05    Database Error in model products_to_inactive_ingredients (models/marts/products/products_to_inactive_ingredients.sql)
[2025-01-13, 16:31:05 PST] {subprocess.py:93} INFO -   relation "sagerx_dev.usp_preservatives" does not exist
[2025-01-13, 16:31:05 PST] {subprocess.py:93} INFO -   LINE 23:     select * from "sagerx"."sagerx_dev"."usp_preservatives"

I checked, and indeed the `usp_preservatives` table was missing from the database. I saw the `usp_preservatives.csv` file in the seeds directory of the repo, and while the seeds configuration appeared to be correct, I couldn't find `dbt seed` being called anywhere in the repo, which would explain why the table wasn't populating.

So, I added a `dbt seed` command to `transform_tasks()`, and the problem now appears to be solved.

## Rationale
I'm a noob when it comes to Airflow and DBT (but always happy to learn!), so it's possible that there's a better way to do this (or a more appropriate place to put it) -- feel free to edit as you see fit.

## Tests
Re-ran `build_marts` DAG successfully