### PR TITLE
Add headers to requests

### DIFF
--- a/airflow/dags/sagerx.py
+++ b/airflow/dags/sagerx.py
@@ -41,7 +41,11 @@ def download_dataset(url: str, dest: Path = Path.cwd(), file_name: str = None):
     import requests
     import re
 
-    with requests.get(url, stream=True, allow_redirects=True) as r:
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+    }
+
+    with requests.get(url, stream=True, allow_redirects=True, headers=headers) as r:
         r.raise_for_status()
 
         if file_name == None:


### PR DESCRIPTION
Fixes #340 

## Explanation
Per suggestion from @Bridg109 - adding headers to the requests call to FDA data source. He gave me these headers and when I plugged them in, everything was working again.

## Rationale
See notes in #340 for why I had to make this change.

## Tests
Have been running SageRx for a few weeks on this branch with no issues.