### PR TITLE
Fix typo in RxNorm transform

### DIFF
--- a/airflow/dags/rxnorm/dag.py
+++ b/airflow/dags/rxnorm/dag.py
@@ -41,6 +41,6 @@ def rxnorm():
 
     transform_task = transform(dag_id, models_subdir=['staging', 'intermediate'])
 
-    extract_task >> load >> transform()
+    extract_task >> load >> transform_task
 
 rxnorm()


### PR DESCRIPTION
## Explanation
It threw an error. I fixed it. Not sure when this started.
