### PR TITLE
Jrlegrand/dailymed part fix

### DIFF
--- a/airflow/dags/dailymed/dag.py
+++ b/airflow/dags/dailymed/dag.py
@@ -28,7 +28,9 @@ def dailymed():
     # - "dm_spl_release_human_rx_part1" for a given part
     # - "dm_spl_daily_update_MMDDYYYY" for a given date
     #   (replace MMDDYYY with your month, day, and year)
-    file_set = "dm_spl_release_human_rx"
+    file_set = "dm_spl_release_human_rx_part"
+    # NOTE: without the _part at the end, it loads all 5 parts
+    # and then a separate zip that is all 5 combined
 
     def connect_to_ftp_dir(ftp_str: str, dir: str):
         import ftplib

--- a/airflow/dags/dailymed/dag.py
+++ b/airflow/dags/dailymed/dag.py
@@ -143,7 +143,7 @@ def dailymed():
     @task
     def transform():
         subprocess = SubprocessHook()
-        result = subprocess.run_command(['dbt', 'run', '--select', 'models/staging/dailymed', 'models/intermediate/dailymed'], cwd='/dbt/sagerx')
+        result = subprocess.run_command(['dbt', 'run', '--select', 'models/staging/dailymed', 'models/intermediate/dailymed', 'ndcs_to_label_images'], cwd='/dbt/sagerx')
         print("Result from dbt:", result)
 
     extract() >> load() >> transform()


### PR DESCRIPTION
## Explanation
1. Fix issue I recently noticed where dailymed DAG was trying to load all 5 parts and then also a separate file that contained all 5 parts in one file. Now it only loads all five zip files individually.  
2. Made it so that the NDC to label images mart gets run with the transform task for ease of use.

## Rationale
Bug fix and convenience.

## Tests
Ran DAG to completion.

