### PR TITLE
Add additional NDC information in ASHP shortages dataset

### DIFF
--- a/dbt/sagerx/models/staging/ashp/_ashp__models.yml
+++ b/dbt/sagerx/models/staging/ashp/_ashp__models.yml
@@ -1,7 +1,7 @@
 version: 2
 
 models:
-  - name: current_drug_shortages
+  - name: stg_ashp__current_drug_shortages
     description: Current ASHP drug shortages
     columns:
       - name: id
@@ -28,14 +28,11 @@ models:
       - name: updated_date
         description: The date the shortage record was last updated by ASHP
 
-  - name: current_drug_shortages_ndcs
+  - name: stg_ashp__current_drug_shortages_ndcs
     description: Affected and available NDCs for each ASHP drug shortage.
     columns:
       - name: id
         description: The ID of the shortage as defined by the detail page URL ID
-        data_tests:
-          - unique
-          - not_null
       - name: product
         description: The NDC product description
       - name: manufacturer

--- a/dbt/sagerx/models/staging/ashp/_ashp__models.yml
+++ b/dbt/sagerx/models/staging/ashp/_ashp__models.yml
@@ -36,8 +36,14 @@ models:
         data_tests:
           - unique
           - not_null
+      - name: product
+        description: The NDC product description
+      - name: manufacturer
+        description: The NDC manufacturer
+      - name: description
+        description: The NDC description relevant to the shortage
       - name: ndc_11
-        description: The NDC relevant to the shortage in NDC-11 format
+        description: The NDC package code in NDC-11 format
       - name: ndc_type
         description: |
           NDC package status as it relates to the shortage

--- a/dbt/sagerx/models/staging/ashp/_ashp__sources.yml
+++ b/dbt/sagerx/models/staging/ashp/_ashp__sources.yml
@@ -38,8 +38,8 @@ sources:
               The partial URL for the shortage detail page,
               containing an id parameter which can be used as
               an index
-          - name: ndc
-            description: The NDC relevant to the shortage
+          - name: ndc_description
+            description: The NDC description statement associated with the shortage
           - name: ndc_type
             description: |
               NDC package status as it relates to the shortage

--- a/dbt/sagerx/models/staging/ashp/stg_ashp__current_drug_shortages_ndcs.sql
+++ b/dbt/sagerx/models/staging/ashp/stg_ashp__current_drug_shortages_ndcs.sql
@@ -4,7 +4,12 @@ with
 
 ashp_shortage_list as (
 
-    select * from {{ source('ashp', 'ashp_shortage_list_ndcs') }}
+    select
+        detail_url,
+        -- Prepare description by removing any commas inside of parentheses
+        regexp_replace(ndc_description, '\(([^)]*),([^)]*)\)', '(\1\2)', 'g') as ndc_description,
+        ndc_type
+    from {{ source('ashp', 'ashp_shortage_list_ndcs') }}
 
 ),
 
@@ -12,7 +17,12 @@ current_drug_shortages_ndcs as (
 
     select
         split_part(detail_url, '=', 2)::int as id,
-        replace(ndc, '-', '') as ndc_11,
+        split_part(ndc_description, ',', 1) as product,
+        split_part(ndc_description, ',', 2) as manufacturer,
+        -- Split NDC description by commas and keep array items 3 through n-1
+        array_to_string((string_to_array(ndc_description, ','))[3:array_upper(string_to_array(ndc_description, ','), 1)-1], ',') as description,
+        -- Get NDC using regular expression
+        replace((regexp_match(ndc_description, '\d{5}\-\d{4}\-\d{2}'))[1], '-', '') as ndc_11,
         ndc_type
     from ashp_shortage_list
 


### PR DESCRIPTION
Resolves #325

## Explanation
Updated ASHP drug shortages dag to pull more granular information for each NDC listed on the individual shortage pages. Previously, the `stg_ashp__current_drug_shortages_ndcs` view contained only columns for id, NDC-11, and shortage type (affected or available). This update adds columns for the drug product, manufacturer, and package description.

## Rationale
These columns can be used to compare against NDC information from other data sources. This was a specific request from #325.

## Tests
Testing was performed manually after rebasing with the most recent commit to main. A sample of the first 10 rows of the updated view are provided:

|id|product|manufacturer|description|ndc_11|ndc_type|
|--|-------|------------|-----------|------|--------|
|1127|5% Sodium Chloride| BBraun| 500 mL bag, 24 count|00264780610|affected|
|1127|5% Sodium Chloride| Baxter| 500 mL bag, 24 count|00338005603|affected|
|1127|Sodium Chloride| BBraun| 3%, 500 mL bag, 24 count|00264780510|affected|
|1127|Sodium Chloride| Baxter| 3% 500 mL bag, 24 count|00338005403|affected|
|1100|0.45% Sodium Chloride injection| BBraun| 1000 mL PVC/DEHP-free bag, 12 count|00264780200|affected|
|1100|0.45% Sodium Chloride injection| BBraun| 500 mL PVC/DEHP-free bag, 24 count|00264780210|affected|
|1100|0.45% Sodium Chloride injection| Baxter| 1000 mL bag, 14 count|00338004304|affected|
|1100|0.45% Sodium Chloride injection| Baxter| 500 mL bag, 24 count|00338004303|affected|
|1100|0.45% Sodium Chloride injection| Fresenius Kabi| 1,000 mL freeflex bag, 10 count|63323062610|affected|
|1100|0.45% Sodium Chloride injection| Fresenius Kabi| 250 mL freeflex bag, 30 count|63323062625|affected|
