### PR TITLE
Fix semicolon error in staging table

### DIFF
--- a/dbt/sagerx/models/staging/rxnorm/stg_rxnorm__hcpcs_codes.sql
+++ b/dbt/sagerx/models/staging/rxnorm/stg_rxnorm__hcpcs_codes.sql
@@ -8,4 +8,4 @@ join sagerx_lake.rxnorm_rxnconso b on a.rxcui = b.rxcui
 where a.atn = 'DHJC'
 and a.atv like 'J%'
 and b.tty in ('GPCK', 'BPCK', 'SCD', 'SBD')
-order by a.atv;
+order by a.atv


### PR DESCRIPTION
## Explanation
Literally just deleted a semicolon in a staging table SQL file.

## Rationale
Threw an error on all transform tasks.

## Tests
Tested a broken DAG task before and after and error was resolved with this change.