### PR TITLE
Remove duplicate model definition

### DIFF
--- a/dbt/sagerx/models/staging/rxclass/_rxclass_models.yml
+++ b/dbt/sagerx/models/staging/rxclass/_rxclass_models.yml
@@ -164,18 +164,6 @@ models:
       - name: class_type
       - name: rela_source
 
-  - name: stg_rxclass__ci_chemclass
-    description: "Drugs that are contraindicated with a chemical class"
-    columns:
-      - name: rxcui
-      - name: name
-      - name: tty
-      - name: rela
-      - name: class_id
-      - name: class_name
-      - name: class_type
-      - name: rela_source
-
   - name: stg_rxclass__has_pk
     description: "Drugs that are members of a Pharmacokinetics Class"
     columns:


### PR DESCRIPTION
Resolves #370 

## Explanation
Deleted a duplicate dbt model definition that was causing errors.

Would like @saywurdson to review to make sure there wasn't supposed to be another model definition in place of this duplicate one. I tried looking through the other models and comparing but there's a lot and I didn't look closely if you wanted to review.

## Rationale
Dbt does not allow duplicate model definitions and it was causing errors.  See related issue #370.

## Tests
I never had this error weirdly, but @eddie-cosma stated it resolved his issue. Also it is just  present in error.