### PR TITLE
Nerf pack size mart to temporarily fix build_marts bug

### DIFF
--- a/dbt/sagerx/models/intermediate/fda/int_fda_packaging_components.sql
+++ b/dbt/sagerx/models/intermediate/fda/int_fda_packaging_components.sql
@@ -79,7 +79,9 @@ total_product as (
 
 	select
 		ndc11,
-		array_product(array_agg(product)) as total_product
+		-- NOTE: had to do this because was breaking build_marts - see #378
+		--array_product(array_agg(product)) as total_product
+		null as total_product
 	from inner_outer_product
 	where product > 0
 	group by ndc11


### PR DESCRIPTION
## Explanation
At one point, the int_fda_packaging_components model required me to multiple an aggregate array and the only way I could do this was with a custom PostgreSQL function. I don't think I ever documented this function (likely from Stackoverflow) and now it's not working. I temporarily replaced the total pack size with a NULL.

## Rationale
This was breaking build_marts.

## Notes
Need to add back the array_product custom function - hence the creation of #378 to track this work.
