### PR TITLE
CMS ASP HCPCS + HCPCS->NDC Crosswalk

### DIFF
--- a/airflow/dags/cms_asp/dag.py
+++ b/airflow/dags/cms_asp/dag.py
@@ -1,0 +1,28 @@
+import pendulum
+
+from airflow_operator import create_dag
+from airflow.providers.postgres.operators.postgres import PostgresOperator
+
+from common_dag_tasks import extract, transform, generate_sql_list, get_ds_folder
+from cms_asp.dag_tasks import load
+from sagerx import read_sql_file
+
+dag_id = "cms_asp"
+
+dag = create_dag(
+    dag_id=dag_id,
+    schedule="0 4 * * *",
+    start_date=pendulum.yesterday(),
+    catchup=False,
+    concurrency=2,
+)
+
+with dag:
+    url= "https://www.cms.gov/files/zip/july-2025-asp-pricing-file-06/11/25-preliminary-file.zip"
+    ds_folder = get_ds_folder(dag_id)
+
+    extract_task = extract(dag_id,url)
+    load_task = load(extract_task)
+    transform_task = transform(dag_id)
+      
+    extract_task >> load_task >> transform_task

--- a/airflow/dags/cms_asp/dag_tasks.py
+++ b/airflow/dags/cms_asp/dag_tasks.py
@@ -1,0 +1,23 @@
+from airflow.decorators import task
+import pandas as pd
+from sagerx import load_df_to_pg
+import glob
+import os
+
+@task
+def load(file_path_str:str):
+    # find the matching file
+    pattern = os.path.join(file_path_str, "*ASP Pricing File*.xls")
+    matching_files = glob.glob(pattern)
+    
+    if not matching_files:
+        raise FileNotFoundError(f"No ASP Pricing File found in {file_path_str}")
+    
+    # use the first matching file
+    file_path = matching_files[0]
+    # skip first 8 rows, use row 9 as header
+    df = pd.read_excel(file_path, header=8)
+    # convert all column names to snake_case
+    df.columns = df.columns.str.lower().str.replace(' ', '_').str.replace('-', '_').str.replace('%', '_percentage')
+    load_df_to_pg(df,"sagerx_lake","cms_asp","replace",index=False)
+    

--- a/airflow/dags/cms_hcpcs/dag.py
+++ b/airflow/dags/cms_hcpcs/dag.py
@@ -1,0 +1,28 @@
+import pendulum
+
+from airflow_operator import create_dag
+from airflow.providers.postgres.operators.postgres import PostgresOperator
+
+from common_dag_tasks import extract, transform, generate_sql_list, get_ds_folder
+from cms_hcpcs.dag_tasks import load
+from sagerx import read_sql_file
+
+dag_id = "cms_hcpcs"
+
+dag = create_dag(
+    dag_id=dag_id,
+    schedule="0 4 * * *",
+    start_date=pendulum.yesterday(),
+    catchup=False,
+    concurrency=2,
+)
+
+with dag:
+    url= "https://www.cms.gov/files/zip/july-2025-alpha-numeric-hcpcs-file.zip"
+    ds_folder = get_ds_folder(dag_id)
+
+    extract_task = extract(dag_id,url)
+    load_task = load(extract_task)
+    transform_task = transform(dag_id)
+      
+    extract_task >> load_task >> transform_task

--- a/airflow/dags/cms_hcpcs/dag_tasks.py
+++ b/airflow/dags/cms_hcpcs/dag_tasks.py
@@ -18,7 +18,7 @@ def load(file_path_str:str):
     
     # Use the first matching file
     file_path = matching_files[0]
-    df = pd.read_excel(file_path, header=8)  # Skip first 8 rows, use row 9 as header
+    df = pd.read_excel(file_path)  # Skip first 8 rows, use row 9 as header
     # convert all column names to snake_case
     df.columns = df.columns.str.lower().str.replace(' ', '_')
     load_df_to_pg(df,"sagerx_lake","cms_hcpcs","replace",index=False)

--- a/airflow/dags/cms_hcpcs/dag_tasks.py
+++ b/airflow/dags/cms_hcpcs/dag_tasks.py
@@ -1,0 +1,25 @@
+from airflow.decorators import task
+import pandas as pd
+from sagerx import load_df_to_pg
+import glob
+import os
+
+@task
+def load(file_path_str:str):
+    # Find the matching file
+    pattern = os.path.join(file_path_str, "HCPC*ANWEB*.xlsx")
+    matching_files = glob.glob(pattern)
+    
+    # Filter out files with Corrections or Transaction in the name
+    matching_files = [f for f in matching_files if 'Corrections' not in f and 'Transaction' not in f]
+    
+    if not matching_files:
+        raise FileNotFoundError(f"No matching HCPC file found in {file_path_str}")
+    
+    # Use the first matching file
+    file_path = matching_files[0]
+    df = pd.read_excel(file_path, header=8)  # Skip first 8 rows, use row 9 as header
+    # convert all column names to snake_case
+    df.columns = df.columns.str.lower().str.replace(' ', '_')
+    load_df_to_pg(df,"sagerx_lake","cms_hcpcs","replace",index=False)
+    

--- a/airflow/dags/cms_ndc_hcpcs_crosswalk/dag.py
+++ b/airflow/dags/cms_ndc_hcpcs_crosswalk/dag.py
@@ -1,0 +1,28 @@
+import pendulum
+
+from airflow_operator import create_dag
+from airflow.providers.postgres.operators.postgres import PostgresOperator
+
+from common_dag_tasks import extract, transform, generate_sql_list, get_ds_folder
+from cms_ndc_hcpcs_crosswalk.dag_tasks import load
+from sagerx import read_sql_file
+
+dag_id = "cms_ndc_hcpcs_crosswalk"
+
+dag = create_dag(
+    dag_id=dag_id,
+    schedule="0 4 * * *",
+    start_date=pendulum.yesterday(),
+    catchup=False,
+    concurrency=2,
+)
+
+with dag:
+    url= "https://www.cms.gov/files/zip/july-2025-asp-ndc-hcpcs-crosswalk-06/11/25-preliminary-file.zip"
+    ds_folder = get_ds_folder(dag_id)
+
+    extract_task = extract(dag_id,url)
+    load_task = load(extract_task)
+    transform_task = transform(dag_id)
+      
+    extract_task >> load_task >> transform_task

--- a/airflow/dags/cms_ndc_hcpcs_crosswalk/dag_tasks.py
+++ b/airflow/dags/cms_ndc_hcpcs_crosswalk/dag_tasks.py
@@ -1,0 +1,22 @@
+from airflow.decorators import task
+import pandas as pd
+from sagerx import load_df_to_pg
+import glob
+import os
+
+@task
+def load(file_path_str:str):
+    # Find the matching file
+    pattern = os.path.join(file_path_str, "*ASP NDC-HCPCS Crosswalk*.xls*")
+    matching_files = glob.glob(pattern)
+    
+    if not matching_files:
+        raise FileNotFoundError(f"No matching NDC-HCPCS Crosswalk file found in {file_path_str}")
+    
+    # Use the first matching file
+    file_path = matching_files[0]
+    df = pd.read_excel(file_path, header=8)  # Skip first 8 rows, use row 9 as header
+    # convert all column names to snake_case
+    df.columns = df.columns.str.lower().str.replace(' ', '_')
+    load_df_to_pg(df,"sagerx_lake","cms_ndc_hcpcs_crosswalk","replace",index=False)
+    

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -5,3 +5,5 @@ dbt-core
 dbt-postgres
 apache-airflow[google]
 bs4
+openpyxl
+xlrd==1.2.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 x-airflow-common: &airflow-common
   build:
     context: ./airflow
-  image: sagerx_airflow:v0.0.5 # versioning allows a rebuild of docker image where necessary
+  image: sagerx_airflow:v0.0.7 # versioning allows a rebuild of docker image where necessary
   networks:
       - airflow-dbt-network
   env_file:


### PR DESCRIPTION
Resolves #381 
Resolves #382 
Resolves #395 

## Explanation
DAG to pull down CMS ASP + HCPCS + HCPCS to NDC crosswalk.

Unfortunately this data is hosted as Excel in the easiest to use format so we need to include a python package that can extract Excel data. I know it will be useful for other data sources so it's not just a one-off.

## Rationale
Useful for Medicare Part B billing analysis.

## Tests
Ran DAG to completion.

This requires a version increase of at least Airflow in dockerfile to re-build the container with the python excel package.