### PR TITLE
Create NDC-level inactive ingredient flags for gluten and dye

### DIFF
--- a/dbt/sagerx/models/intermediate/fda_unii/int_fda_unii.sql
+++ b/dbt/sagerx/models/intermediate/fda_unii/int_fda_unii.sql
@@ -1,0 +1,41 @@
+-- int_fda_unii.sql
+
+with
+
+gluten_unii_codes as (
+
+    select
+        *,
+        true as is_true,
+        1 as count    
+    from {{ ref('fda_unii_excipient_gluten') }}
+
+),
+
+dye_unii_codes as (
+
+    select
+        *,
+        true as is_true,
+        1 as count        
+    from {{ ref('fda_unii_excipient_dye') }}
+
+),
+
+fda_unii as (
+
+    select 
+        fda_unii.*,
+        gluten.is_true as is_gluten,
+        gluten.count as gluten_count,
+        dye.is_true as is_dye,
+        dye.count as dye_count
+    from {{ ref('stg_fda_unii__unii_codes') }} fda_unii
+    left join gluten_unii_codes gluten
+        on fda_unii.unii = gluten.fda_unii_code
+    left join dye_unii_codes dye
+        on fda_unii.unii = dye.fda_unii_code
+
+)
+
+select * from fda_unii

--- a/dbt/sagerx/models/intermediate/fda_unii/int_fda_unii_ndcs.sql
+++ b/dbt/sagerx/models/intermediate/fda_unii/int_fda_unii_ndcs.sql
@@ -1,0 +1,74 @@
+-- int_fda_unii_ndcs.sql
+
+with
+
+inactive_ingredients as (
+    
+    select
+        *
+    from {{ ref('int_mthspl_products_to_inactive_ingredients') }}
+
+),
+
+fda_unii as (
+
+    select
+        *
+    from {{ ref('int_fda_unii') }}
+
+),
+
+ndc_detail as (
+
+    select
+        *
+    from inactive_ingredients iact
+    left join fda_unii
+        on iact.inactive_ingredient_unii = fda_unii.unii
+
+),
+
+ndc_summary as (
+
+    select
+        ndc9,
+        ndc,
+        product_rxcui,
+        product_name,
+        product_tty,
+        bool_or(is_gluten) as has_gluten,
+        sum(gluten_count) as gluten_count,
+        bool_or(is_dye) as has_dye,
+        sum(dye_count) as dye_count
+    from ndc_detail
+    group by
+        ndc9,
+        ndc,
+        product_rxcui,
+        product_name,
+        product_tty
+
+),
+
+ndc9_to_ndc11 as (
+
+    select
+        left(ndc11, 9) as ndc9,
+        ndc11
+    from {{ ref('int_rxnorm_all_ndcs_to_product_rxcuis') }}
+    where left(ndc11, 9) in (select distinct ndc9 from ndc_summary)
+
+),
+
+ndc_summary_with_ndc11 as (
+
+    select
+        ndc9_to_ndc11.ndc11,
+        ndc_summary.*
+    from ndc_summary
+    left join ndc9_to_ndc11
+        on ndc_summary.ndc9 = ndc9_to_ndc11.ndc9
+
+)
+
+select * from ndc_summary_with_ndc11


### PR DESCRIPTION
## Explanation
Created two intermediate models that map NDC9 of inactive ingredient mart to NDC11 and then flag each NDC11 as possibly containing dye and/or gluten.

Huge thanks to Kyle McCormick and his staff / interns at Blueberry Pharmacy for creating the mapping of inactive ingredients to gluten and/or dye.

## Rationale
Could be useful

Likely still need to add this to the all_ndc_descriptions mart or something like that. Or maybe an ndc_warnings mart or something. TBD...

## Tests
Ran the dbt models.